### PR TITLE
Main Window: Consistent style of main toolbar

### DIFF
--- a/files/styles/style-indoor.css
+++ b/files/styles/style-indoor.css
@@ -345,6 +345,14 @@ QMenu::separator {
      margin-right: 5px;
  }
 
+QMenuBar {
+    background: black;
+}
+
+QMenuBar::item {
+    background: black;
+}
+
 QMenuBar::item:disabled {
     border: none;
     background: none;

--- a/files/styles/style-indoor.css
+++ b/files/styles/style-indoor.css
@@ -334,6 +334,8 @@ QToolButton:pressed {
 
 QMenu {
     border: 1px solid #379AC3;
+    background: black;
+    color: white;
 }
 
 QMenu::separator {
@@ -351,6 +353,10 @@ QMenuBar {
 
 QMenuBar::item {
     background: black;
+}
+
+QMenu::item::selected {
+        background: rgb(100, 100, 100);
 }
 
 QMenuBar::item:disabled {

--- a/files/styles/style-outdoor.css
+++ b/files/styles/style-outdoor.css
@@ -196,6 +196,20 @@ QMainWindow::separator:hover {
 	background: rgb(0, 0, 255);
 }
 
+QMenu {
+    border: 1px solid black;
+}
+
+QMenuBar {
+    background: black;
+    color: white;
+}
+
+QMenuBar::item {
+    background: black;
+    color: white;
+}
+
 QMenu::item::selected {
 	background: rgb(200, 200, 200);
 }

--- a/files/styles/style-outdoor.css
+++ b/files/styles/style-outdoor.css
@@ -197,8 +197,19 @@ QMainWindow::separator:hover {
 }
 
 QMenu {
-    border: 1px solid black;
+    border: 1px solid #379AC3;
+    background: black;
+    color: white;
 }
+
+QMenu::separator {
+     height: 1px;
+     background: #379AC3;
+     margin-top: 8px;
+     margin-bottom: 4px;
+     margin-left: 5px;
+     margin-right: 5px;
+ }
 
 QMenuBar {
     background: black;
@@ -211,8 +222,9 @@ QMenuBar::item {
 }
 
 QMenu::item::selected {
-	background: rgb(200, 200, 200);
+        background: rgb(100, 100, 100);
 }
+
 QMenuBar::item:disabled {
 	border: none;
 	background: none;


### PR DESCRIPTION
The main window toolbar would follow the style of host OS (bright blue with Windows 7, or two tone gray on Ubuntu for example). Will now always have black background (to match the APM toolbar) and white text with either indoor or outdoor style/color. 'Inner' menus still follow the dark/light style.