### PR TITLE
Serial Link: Bugfix #946

### DIFF
--- a/src/comm/serialconnection.cc
+++ b/src/comm/serialconnection.cc
@@ -90,8 +90,14 @@ void SerialConnection::portError(QSerialPort::SerialPortError serialPortError)
             }
         }
     case QSerialPort::ResourceError:
-        disconnect();
-        break;
+        {
+            // In case of error disconnect from error signal to avoid endless looping
+            // if another error is signalled while disconnecting
+            QObject::disconnect(m_port, SIGNAL(error(QSerialPort::SerialPortError)),
+                                this, SLOT(portError(QSerialPort::SerialPortError)));
+            disconnect();
+            break;
+        }
     case QSerialPort::NotOpen:
     case QSerialPort::OpenError:
     default:
@@ -415,6 +421,7 @@ bool SerialConnection::disconnect()
     QLOG_DEBUG() << "SerialConnection::disconnect()" << m_port;
     if (m_port)
     {
+
         m_port->close();
         m_port->deleteLater();
         m_port = 0;


### PR DESCRIPTION
The crash was caused by an endless loop. 

disconnect USB -> error signal -> call to portError() -> call to disconnect() -> error signal -> call to porError() -> call to disconnect() -> error signal .......

Gave an incredible backtrace - the gdb crashed while generating :smile: 
