### PR TITLE
Enlarge m_buttonStates array to prevent crash

### DIFF
--- a/src/ui/JoystickWidget.h
+++ b/src/ui/JoystickWidget.h
@@ -100,7 +100,7 @@ private:
     Ui::JoystickWidget *m_ui;
     JoystickInput* joystick;  ///< Reference to the joystick
 
-    int m_buttonStates[11];
+    int m_buttonStates[64];
 
     QString m_buttonPressedMessage;
 


### PR DESCRIPTION
Enlarge m_buttonStates array member to next "maximum" value to prevent segfault in case of connecting joystick with more, than 11 buttons (reproducible e.g. with Sony DualShock 3).

Generally, if it's possible, maybe some dynamic container would be even safer here.