### PR TITLE
BUGFIX: Datamodel now accepts FMT inserts after data inserts. Fixes #980

### DIFF
--- a/src/ui/AP2DataPlot2DModel.cc
+++ b/src/ui/AP2DataPlot2DModel.cc
@@ -404,6 +404,10 @@ bool AP2DataPlot2DModel::addType(const QString &name, const unsigned int type, c
         QString variablenames = names.join(",");
         QString insertstring = makeInsertTableString(name,names);
 
+        // HACK: This line allows inserting a FMT message after inserting some data.
+        // without this a late FMT message would lead to an index failure.
+        m_fmtIndex = m_fmtIndex > m_lastIndex  ? m_fmtIndex : m_lastIndex + 1;
+
         //if (!query->prepare("INSERT INTO 'FMT' (idx,typeid,length,name,format,val) values (:idx,:typeid,:length,:name,:format,:val);"))
         m_fmtInsertQuery->bindValue(":idx",m_fmtIndex++);
         m_fmtInsertQuery->bindValue(":typeid",type);

--- a/src/ui/AP2DataPlot2DModel.h
+++ b/src/ui/AP2DataPlot2DModel.h
@@ -175,7 +175,7 @@ private:
     int m_rowCount;                 /// Stores the number of rows held in model.
     int m_columnCount;
     int m_currentRow;
-    int m_fmtIndex;
+    quint64 m_fmtIndex;
 
     quint64 m_firstIndex;
     quint64 m_lastIndex;


### PR DESCRIPTION
This should fix it. It is a hack - but it works. The real problem is that the data model counts the index for the FMT messages and the parser counts the index for the data messages. Perhaps we should remove the index handling from the parser and make the index handling in the data model. I think the index is somehow an internal of the data model, so the parser should not know about.
As I'm doing a complete re factoring of the parsers at the moment I will see if I can fix it during this task.