### PR TITLE
Index fix for data model

### DIFF
--- a/src/ui/AP2DataPlot2DModel.cc
+++ b/src/ui/AP2DataPlot2DModel.cc
@@ -535,7 +535,7 @@ bool AP2DataPlot2DModel::endTransaction()
     return true;
 }
 
-bool AP2DataPlot2DModel::addRow(const QString &name, const QList<QPair<QString,QVariant> >  &values, const int index, const QString &timeColName)
+bool AP2DataPlot2DModel::addRow(const QString &name, const QList<QPair<QString,QVariant> >  &values, const QString &timeColName)
 {
 
     //Add a row to a previously defined message type using the already prepared insert query

--- a/src/ui/AP2DataPlot2DModel.h
+++ b/src/ui/AP2DataPlot2DModel.h
@@ -47,7 +47,7 @@ public:
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole ) const;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const;
     bool addType(const QString &name, const unsigned int type, const int length, const QString &types, const QStringList &names);
-    bool addRow(const QString &name, const QList<QPair<QString,QVariant> >  &values, const int index, const QString &timeColName);
+    bool addRow(const QString &name, const QList<QPair<QString,QVariant> >  &values, const QString &timeColName);
     QMap<QString,QList<QString> > getFmtValues();
     QString getFmtLine(const QString& name);
     void getMessagesOfType(const QString &type, QMap<quint64, MessageBase::Ptr> &indexToMessageMap);

--- a/src/ui/AP2DataPlot2DModel.h
+++ b/src/ui/AP2DataPlot2DModel.h
@@ -151,6 +151,8 @@ private: //helpers
     bool setUpMaxTime();
 
 private:
+    static const int s_DataRowOffset = 500;     /// Index offset for first data row. This allows max 499 FMT rows!
+
     QString m_error;
     QString m_databaseName;
     QVector<QPair<quint64,QString> > m_rowIndexToDBIndex;   /// stores relation between Table row index
@@ -175,10 +177,9 @@ private:
     int m_rowCount;                 /// Stores the number of rows held in model.
     int m_columnCount;
     int m_currentRow;
-    int m_fmtIndex;
+    int m_fmtIndex;         /// Index for FMT (type) rows
 
-    quint64 m_firstIndex;
-    quint64 m_lastIndex;
+    quint64 m_lastIndex;    /// holds last data row index increases when adding row
 
     queryPtr m_indexinsertquery;
     queryPtr m_fmtInsertQuery;

--- a/src/ui/AP2DataPlotThread.cc
+++ b/src/ui/AP2DataPlotThread.cc
@@ -419,7 +419,7 @@ void AP2DataPlotThread::loadBinaryLog(QFile &logfile)
 
                             if (noCorruptDataFound && (valuepairlist.size() >= 1))
                             {
-                                if (!m_dataModel->addRow(name, valuepairlist, index, m_timeStamp.m_name))
+                                if (!m_dataModel->addRow(name, valuepairlist, m_timeStamp.m_name))
                                 {
                                     QString actualerror = m_dataModel->getError();
                                     m_dataModel->endTransaction(); //endTransaction can re-set the error if it errors, but we should try it anyway.
@@ -759,13 +759,14 @@ void AP2DataPlotThread::loadAsciiLog(QFile &logfile)
 
                                 if (valuepairlist.size() >= 1)
                                 {
-                                    if (!m_dataModel->addRow(name,valuepairlist,index++, m_timeStamp.m_name))
+                                    if (!m_dataModel->addRow(name,valuepairlist, m_timeStamp.m_name))
                                     {
                                         QString actualerror = m_dataModel->getError();
                                         m_dataModel->endTransaction(); //endTransaction can re-set the error if it errors, but we should try it anyway.
                                         emit error(actualerror);
                                         return;
                                     }
+                                    index++;
                                     m_plotState.validDataRead();
                                 }
                             }
@@ -980,13 +981,14 @@ void AP2DataPlotThread::loadTLog(QFile &logfile)
                             // check if a synthetic timestamp has to added
                             handleMissingTimeStamps(timeStampHasToBeAdded, desc.m_name, valuepairlist, lastValidTS, index);
 
-                            if (!m_dataModel->addRow(desc.m_name,valuepairlist, index++, m_timeStamp.m_name))
+                            if (!m_dataModel->addRow(desc.m_name,valuepairlist, m_timeStamp.m_name))
                             {
                                 QString actualerror = m_dataModel->getError();
                                 m_dataModel->endTransaction(); //endTransaction can re-set the error if it errors, but we should try it anyway.
                                 emit error(actualerror);
                                 return;
                             }
+                            index++;
 
                             // Tlog does not contain MODE messages the mode information ins transmitted in
                             // a heartbeat message. So here we extract MODE data from hertbeat
@@ -1003,13 +1005,14 @@ void AP2DataPlotThread::loadTLog(QFile &logfile)
                                     specialValuepairlist.append(QPair<QString, QVariant>(modeVarNames[1], lastModeVal));
                                     specialValuepairlist.append(QPair<QString, QVariant>(modeVarNames[2], lastModeVal));
                                     specialValuepairlist.append(QPair<QString, QVariant>(modeVarNames[3], "Generated Value"));
-                                    if (!m_dataModel->addRow(ModeMessage::TypeName, specialValuepairlist, index++, m_timeStamp.m_name))
+                                    if (!m_dataModel->addRow(ModeMessage::TypeName, specialValuepairlist, m_timeStamp.m_name))
                                     {
                                         QString actualerror = m_dataModel->getError();
                                         m_dataModel->endTransaction(); //endTransaction can re-set the error if it errors, but we should try it anyway.
                                         emit error(actualerror);
                                         return;
                                     }
+                                    index++;
 
                                     // Mav type can be extracted from heartbeat too. So lets set the Mav type
                                     // if not already set
@@ -1035,13 +1038,14 @@ void AP2DataPlotThread::loadTLog(QFile &logfile)
                                 specialValuepairlist.append(QPair<QString, QVariant>(msgVarNames[0], lastValidTS));
                                 specialValuepairlist.append(QPair<QString, QVariant>(msgVarNames[1], valuepairlist[2].second));
                                 specialValuepairlist.append(QPair<QString, QVariant>(msgVarNames[2], "Generated Value"));
-                                if (!m_dataModel->addRow(MsgMessage::TypeName, specialValuepairlist, index++, m_timeStamp.m_name))
+                                if (!m_dataModel->addRow(MsgMessage::TypeName, specialValuepairlist, m_timeStamp.m_name))
                                 {
                                     QString actualerror = m_dataModel->getError();
                                     m_dataModel->endTransaction(); //endTransaction can re-set the error if it errors, but we should try it anyway.
                                     emit error(actualerror);
                                     return;
                                 }
+                                index++;
                             }
                             m_plotState.validDataRead();    // tell plot state that we have a valid message
                         }


### PR DESCRIPTION
Hi all,
after reverting my last hack cause it broke the tlog parsing here comes the next approach!
The main issue was that the DB-index for FMT messages was generated by the datamodel and the DB-index for the data rows was generated by the parser.
I migrated the index generation completely into the data model. The only drawback of this solution is a hard coded offset for the data rows. This means the data model can take max 500 FMT lines. If there are more it will generate an Index failure. I don't think this is a real issue as the binary logs only have a quint8 for the message ID which results in max 255 different FMT messages. So the offset of 500 should be big enough.
The other solution - working without offset and let everything be dynamic - leads to the problem that if you receive FMT messages when already receiving data (which is normal in tlogs) your index increases without a dataline. In the default graph view the index is used on the X-axis. So an index increase without a dataline would lead to a gap in x-axis values.
Therefore I thought an offset would be the better solution.