### PR TITLE
Change to rules for Debian/Ubuntu

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -28,7 +28,7 @@ build:
 	#GIT_VERSION=$(git describe --abbrev=1)
 	#git-dch -a --ignore-branch --new-version="2.0.0.$GIT_VERSION"
 	./debian/gitlog-to-changelog.pl > ./debian/changelog
-	qmake PREFIX=debian/tmp/usr qgroundcontrol.pro ${APP_PLATFORM_DEFINES}
+	qmake PREFIX=debian/tmp/usr apm_planner.pro ${APP_PLATFORM_DEFINES}
 	#cmake -DCMAKE_INSTALL_PREFIX=/usr .
 	#$(MAKE) CC="$(CC)" CFLAGS="$(CFLAGS)" --jobs=3
 	touch build
@@ -37,7 +37,7 @@ clean:
 	$(checkdir)
 	rm -f build
 	#cmake -DCMAKE_INSTALL_PREFIX=/usr .
-	qmake PREFIX=/usr qgroundcontrol.pro ${APP_PLATFORM_DEFINES}
+	qmake PREFIX=/usr apm_planner.pro ${APP_PLATFORM_DEFINES}
 	[ ! -f Makefile ] || $(MAKE) clean
 	rm -r Makefile
 	rm -rf *~ debian/tmp debian/*~ debian/files* debian/substvars
@@ -69,7 +69,7 @@ binary-arch: checkroot build
 	dpkg-deb --build debian/tmp ..
 
 define checkdir
-	test -f qgroundcontrol.pro -a -f debian/rules
+	test -f apm_planner.pro -a -f debian/rules
 endef
 
 binary: binary-indep binary-arch


### PR DESCRIPTION
debian/rules changed due to rename of project file to apm_planner.pro for debian builds.