### PR TITLE
Bugfix and some more - Fixes #997

### DIFF
--- a/src/ui/LogParser/AsciiLogParser.cpp
+++ b/src/ui/LogParser/AsciiLogParser.cpp
@@ -148,7 +148,7 @@ AP2DataPlotStatus AsciiLogParser::parse(QFile &logfile)
                         {
                             return m_logLoadingState;
                         }
-                        if((m_loadedLogType == MAV_TYPE_GENERIC) && (descriptor.m_name == "PARM"))
+                        if(m_loadedLogType == MAV_TYPE_GENERIC)
                         {
                             detectMavType(NameValuePairList);
                         }

--- a/src/ui/LogParser/AsciiLogParser.cpp
+++ b/src/ui/LogParser/AsciiLogParser.cpp
@@ -238,7 +238,6 @@ bool AsciiLogParser::storeDescriptor(asciiDescriptor desc)
                 }
 
                 m_dataStoragePtr->addDataType(desc.m_name, desc.m_ID, desc.m_length, desc.m_format, desc.m_labels, desc.m_timeStampIndex);
-                m_MessageCounter++;
             }
         }
         else

--- a/src/ui/LogParser/BinLogParser.cpp
+++ b/src/ui/LogParser/BinLogParser.cpp
@@ -242,7 +242,6 @@ bool BinLogParser::storeDescriptor(binDescriptor desc)
                 }
 
                 m_dataStoragePtr->addDataType(desc.m_name, desc.m_ID, desc.m_length, desc.m_format, desc.m_labels, desc.m_timeStampIndex);
-                m_MessageCounter++;
             }
         }
         else

--- a/src/ui/LogParser/LogParserBase.cpp
+++ b/src/ui/LogParser/LogParserBase.cpp
@@ -173,7 +173,7 @@ void LogParserBase::readTimeStamp(QList<NameValuePair> &valuepairlist, const typ
     {
         if(m_timeErrorCount < 50)
         {
-            QLOG_WARN() << "Corrupt data read: Time is not increasing! Last valid time stamp:"
+            QLOG_WARN() << "Corrupt data read: Time for " << desc.m_name << " is not increasing! Last valid time stamp:"
                         << QString::number(m_lastValidTimePerType[desc.m_name]) << " actual read time stamp is:"
                         << QString::number(tempVal);
 
@@ -184,9 +184,9 @@ void LogParserBase::readTimeStamp(QList<NameValuePair> &valuepairlist, const typ
             QLOG_WARN() << "Supressing further time is not increasing messages....";
             ++m_timeErrorCount;
         }
-        m_logLoadingState.corruptTimeRead(static_cast<int>(m_MessageCounter), "Log time is not increasing! Last Time:" +
-                                          QString::number(m_lastValidTimePerType[desc.m_name]) + " new Time:" +
-                                          QString::number(tempVal));
+        m_logLoadingState.corruptTimeRead(static_cast<int>(m_MessageCounter), "Log time for " + desc.m_name +
+                                          " is not increasing! Last Time:" + QString::number(m_lastValidTimePerType[desc.m_name]) +
+                                          " new Time:" + QString::number(tempVal));
         // if not increasing set to last valid value
         valuepairlist[desc.m_timeStampIndex].second = m_lastValidTimePerType[desc.m_name];
     }

--- a/src/ui/LogParser/LogParserBase.h
+++ b/src/ui/LogParser/LogParserBase.h
@@ -170,6 +170,16 @@ protected:
      */
     void detectMavType(const QList<NameValuePair> &valuepairlist);
 
+    /**
+     * @brief repairMessage tries to repair a message to match the descriptor.
+     *        Missing fields will be added and set to 0. If there are too many fields
+     *        they are cut.
+     * @param NameValuePairList - list that needs repair.
+     * @param descriptor - descriptor describing the message type.
+     * @return true - message is ok, false otherwise.
+     */
+    bool repairMessage(QList<NameValuePair> &NameValuePairList, const typeDescriptor &desc);
+
 };
 
 #endif // LOGPARSERBASE_H

--- a/src/ui/LogParser/LogParserBase.h
+++ b/src/ui/LogParser/LogParserBase.h
@@ -136,7 +136,8 @@ protected:
 
     QList<timeStampType> m_possibleTimestamps;            /// List of possible timestamps. Filled in CTOR
     timeStampType m_activeTimestamp;                      /// the detected timestamp used for parsing
-    quint64 m_lastValidTimeStamp;                         /// Contains always the last valid timestamp
+    QHash<QString, quint64> m_lastValidTimePerType;       /// Contains the last valid timestamp for each type (which have a timestamp)
+    quint64 m_highestTimestamp;                           /// Contains always the biggest timestamp
 
 
     /**

--- a/src/ui/LogParser/TlogParser.cpp
+++ b/src/ui/LogParser/TlogParser.cpp
@@ -361,10 +361,10 @@ bool TlogParser::extractModeMessage(const QList<NameValuePair> &NameValuePairLis
     {
         QList<NameValuePair> modeValuePairlist;
         tlogDescriptor modeDesc = m_nameToDescriptorMap.value(ModeMessage::TypeName);
-        // Extract MODE messages from heratbeat messages
+        // Extract MODE messages from heartbeat messages
         m_lastModeVal = static_cast<quint8>(NameValuePairList[1].second.toInt());
 
-        modeValuePairlist.append(QPair<QString, QVariant>(modeDesc.m_labels[0], m_lastValidTimeStamp));
+        modeValuePairlist.append(QPair<QString, QVariant>(modeDesc.m_labels[0], m_highestTimestamp));
         modeValuePairlist.append(QPair<QString, QVariant>(modeDesc.m_labels[1], m_lastModeVal));
         modeValuePairlist.append(QPair<QString, QVariant>(modeDesc.m_labels[2], m_lastModeVal));
         modeValuePairlist.append(QPair<QString, QVariant>(modeDesc.m_labels[3], "Generated from heartbeat"));
@@ -387,7 +387,7 @@ bool TlogParser::extractMsgMessage(const QList<NameValuePair> &NameValuePairList
 
     if((msgDesc.m_labels.size() >= 2) && (NameValuePairList.size() >= 2))
     {
-        msgValuePairlist.append(QPair<QString, QVariant>(msgDesc.m_labels[0], m_lastValidTimeStamp));
+        msgValuePairlist.append(QPair<QString, QVariant>(msgDesc.m_labels[0], m_highestTimestamp));
         msgValuePairlist.append(QPair<QString, QVariant>(msgDesc.m_labels[1], NameValuePairList[2].second));
         msgValuePairlist.append(QPair<QString, QVariant>(msgDesc.m_labels[2], "Generated from statustext"));
         if (!storeNameValuePairList(msgValuePairlist, msgDesc))

--- a/src/ui/LogParser/TlogParser.cpp
+++ b/src/ui/LogParser/TlogParser.cpp
@@ -296,7 +296,6 @@ bool TlogParser::storeDescriptor(tlogDescriptor desc)
         }
 
         m_dataStoragePtr->addDataType(desc.m_name, desc.m_ID, desc.m_length, desc.m_format, desc.m_labels, desc.m_timeStampIndex);
-        m_MessageCounter++;
     }
     else
     {
@@ -423,6 +422,7 @@ bool TlogParser::repairMessage(QList<NameValuePair> &NameValuePairList, const tl
 
         if(!found)
         {
+            // this value is missing in message add one with value 0
             NameValuePair pair(label, QVariant(0));
             NameValuePairList.append(pair);
         }

--- a/src/ui/LogParser/TlogParser.h
+++ b/src/ui/LogParser/TlogParser.h
@@ -133,15 +133,6 @@ private:
      */
     bool extractMsgMessage(const QList<NameValuePair> &NameValuePairList);
 
-    /**
-     * @brief repairMessage tries to repair a message to match the descriptor.
-     *        Missing fields will be added and set to 0. If there are too many fields
-     *        they are cut.
-     * @param NameValuePairList - list that needs repair.
-     * @param descriptor - descriptor describing the message type.
-     * @return true - message is ok, false otherwise.
-     */
-    bool repairMessage(QList<NameValuePair> &NameValuePairList, const tlogDescriptor &descriptor);
 };
 
 #endif // TLOGPARSER_H

--- a/src/ui/LogParser/TlogParser.h
+++ b/src/ui/LogParser/TlogParser.h
@@ -132,6 +132,16 @@ private:
      * @return - true success, false datamodel failure
      */
     bool extractMsgMessage(const QList<NameValuePair> &NameValuePairList);
+
+    /**
+     * @brief repairMessage tries to repair a message to match the descriptor.
+     *        Missing fields will be added and set to 0. If there are too many fields
+     *        they are cut.
+     * @param NameValuePairList - list that needs repair.
+     * @param descriptor - descriptor describing the message type.
+     * @return true - message is ok, false otherwise.
+     */
+    bool repairMessage(QList<NameValuePair> &NameValuePairList, const tlogDescriptor &descriptor);
 };
 
 #endif // TLOGPARSER_H


### PR DESCRIPTION
Hi all,
my new PR with a fix for #997 and some other goodies :smiley: 
Messages with a datafield mismatch will be "repaired". This means if the number of datafields in a message does not match the number stored in its descriptor the message gets reconstructed. This is done by creating a new message based on the format stored in the descriptor which will be enriched with all valid data which can be found in the original message. Values that are missing will be set to zero and values which can not be collated are dropped. All repairings are logged with its index.