### PR TITLE
libs: quazip: add definition for OF macro

### DIFF
--- a/libs/thirdParty/quazip/ioapi.h
+++ b/libs/thirdParty/quazip/ioapi.h
@@ -37,6 +37,10 @@
 extern "C" {
 #endif
 
+#ifndef OF
+#define OF _Z_OF
+#endif
+
 typedef voidpf (ZCALLBACK *open_file_func) OF((voidpf opaque, voidpf file, int mode));
 typedef uLong  (ZCALLBACK *read_file_func) OF((voidpf opaque, voidpf stream, void* buf, uLong size));
 typedef uLong  (ZCALLBACK *write_file_func) OF((voidpf opaque, voidpf stream, const void* buf, uLong size));


### PR DESCRIPTION
Compilation fails on my gentoo box, as quazip doesn't find a definition
of the OF macro.

However, the macro can be substituted by _Z_OF() (stolen from mainline
quazip code). This makes apm_planner compile on Gentoo and doesn't hurt
other systems.

Signed-off-by: Ralf Ramsauer <ralf.ramsauer@oth-regensburg.de>