### PR TITLE
Build: Refactor docker directory, create/update Dockerfiles

### DIFF
--- a/docker/2.0.20-wily64/Dockerfile
+++ b/docker/2.0.20-wily64/Dockerfile
@@ -1,0 +1,15 @@
+# USAGE:
+#
+#	# Build apmplanner2 image
+#	docker build -t apmplanner2 .
+#
+#	docker run -v /tmp/.X11-unix:/tmp/.X11-unix \
+#		-e DISPLAY=unix$DISPLAY --device /dev/ttyS0:/dev/ttyS0 apmplannner2
+FROM ubuntu:15.10
+MAINTAINER Rik Bruggink <mail@rikbruggink.nl>, Eduardo Feo <eduardo@idsia.ch>
+RUN apt-get -y update && apt-get -y upgrade && apt-get -y install wget
+RUN wget http://firmware.ardupilot.org/Tools/APMPlanner/archive/apm_planner_2.0.20_ubuntu_wily64.deb
+RUN dpkg -i apm_planner_2.0.20_ubuntu_wily64.deb; exit 0
+RUN apt-get -f -y install
+RUN rm -rf /var/lib/apt/lists/*
+ENTRYPOINT [ "/usr/bin/apmplanner2"]

--- a/docker/2.0.24-xenial64/Dockerfile
+++ b/docker/2.0.24-xenial64/Dockerfile
@@ -5,10 +5,12 @@
 #
 #	docker run -v /tmp/.X11-unix:/tmp/.X11-unix \
 #		-e DISPLAY=unix$DISPLAY --device /dev/ttyS0:/dev/ttyS0 apmplannner2
-FROM ubuntu:15.10
-MAINTAINER Rik Bruggink <mail@rikbruggink.nl>
+FROM ubuntu:xenial
+MAINTAINER Rik Bruggink <mail@rikbruggink.nl>, Eduardo Feo <eduardo@idsia.ch>
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y install wget
-RUN wget http://firmware.ardupilot.org/Tools/APMPlanner/apm_planner_2.0.20_ubuntu_wily64.deb
-RUN dpkg -i apm_planner_2.0.20_ubuntu_wily64.deb; exit 0
+RUN wget http://firmware.eu.ardupilot.org/Tools/APMPlanner/apm_planner_2.0.24_xenial64.deb
+RUN dpkg -i apm_planner_2.0.24_xenial64.deb; exit 0
 RUN apt-get -f -y install
+RUN rm -rf /var/lib/apt/lists/*
+VOLUME /root/apmplanner2
 ENTRYPOINT [ "/usr/bin/apmplanner2"]


### PR DESCRIPTION
The previous Dockerfile was outdated: the URL to download the firmware was not valid anymore.
This pull request will fix that. In addition, I think that, instead of constantly updating the Dockerfile each time a new release is made, we could refactor the directory 'docker' to contain all the Dockerfiles that have been created for previous and current releases. To this end, we create a sub-directory named "release-distribution" that contains the Dockerfile for the specific release of apmplanner2 and the linux distribution.

In anycase, I think that the best would be to use dockerhub to distribute pre-built images of apmplanner2.