### PR TITLE
Preset feature and bugfixes

### DIFF
--- a/apm_planner.pro
+++ b/apm_planner.pro
@@ -687,7 +687,8 @@ HEADERS += \
     src/ui/Loghandling/TlogParser.h \
     src/ui/Loghandling/LogdataStorage.h \
     src/ui/Loghandling/LogExporter.h \
-    src/ui/Loghandling/LogAnalysis.h
+    src/ui/Loghandling/LogAnalysis.h \
+    src/ui/Loghandling/PresetManager.h
 
 SOURCES += src/main.cc \
     src/QGCCore.cc \
@@ -913,7 +914,8 @@ SOURCES += src/main.cc \
     src/ui/Loghandling/TlogParser.cpp \
     src/ui/Loghandling/LogdataStorage.cpp \
     src/ui/Loghandling/LogExporter.cpp \
-    src/ui/Loghandling/LogAnalysis.cpp
+    src/ui/Loghandling/LogAnalysis.cpp \
+    src/ui/Loghandling/PresetManager.cpp
 
 MacBuild | WindowsBuild : contains(GOOGLEEARTH, enable) { #fix this to make sense ;)
     message(Including support for Google Earth)

--- a/src/output/kmlcreator.cc
+++ b/src/output/kmlcreator.cc
@@ -184,7 +184,9 @@ QString SummaryData::summarize() {
 }
 
 KMLCreator::KMLCreator():
-    m_summary(new SummaryData()) {
+    m_summary(new SummaryData()),
+    m_newGPSMessage(false)
+{
 }
 
 KMLCreator::~KMLCreator() {
@@ -200,7 +202,8 @@ void KMLCreator::start(QString &fn) {
     m_placemarks.append(pm);
 }
 
-void KMLCreator::processLine(QString &line) {
+void KMLCreator::processLine(QString &line)
+{
     if(line.indexOf("FMT,") == 0) {
         FormatLine fl = FormatLine::from(line);
         if(fl.hasData()) {
@@ -214,6 +217,7 @@ void KMLCreator::processLine(QString &line) {
 
             if(gps.hasData()) {
                 m_summary->add(gps);
+                m_newGPSMessage = true;
 
                 Placemark* pm = lastPlacemark();
                 if(pm) {
@@ -228,12 +232,17 @@ void KMLCreator::processLine(QString &line) {
             }
         }
     }
-    else if(line.indexOf("ATT,") == 0) {
+    // we have a lot more "ATT" messages than "GPS" messages. In order to have a one on one relation
+    // between the two messages we only take one new "ATT" message as soon as we have received a "GPS"
+    // message. Its a very raw correlation but better than nothing. (Better would be timestamp matching).
+    // Nevertheless due to this hack its possible to give the plane model in Google earth the right heading.
+    else if((line.indexOf("ATT,") == 0) && m_newGPSMessage) {
         FormatLine fl = m_formatLines.value("ATT");
         if(fl.hasData()) {
             Attitude att = Attitude::from(fl, line);
 
             if(att.hasData()) {
+                m_newGPSMessage = false;
                 Placemark* pm = lastPlacemark();
                 if(pm) {
                     pm->add(att);
@@ -463,19 +472,15 @@ static QString descriptionData(Placemark *p, GPSRecord &c) {
         m["Yaw"] = a.yaw();
     }
 
-    QString s("<![CDATA[\r\n<table>");
-
+    QString s;
     QHashIterator<QString, QString> iter(m);
     while(iter.hasNext()) {
         iter.next();
         QString key = iter.key();
         QString value = iter.value();
 
-        s += QString("<tr><td><b>%1:</b></td><td>%2</td></tr>").arg(key).arg(value);
+        s += QString("<b>%1:</b>%2<br>").arg(key).arg(value);
     }
-
-    s += "</table>\r\n]]>";
-
     return s;
 }
 
@@ -484,6 +489,7 @@ void KMLCreator::writePlanePlacemarkElement(QXmlStreamWriter &writer, Placemark 
         return;
     }
 
+    int index = 0;
     foreach(GPSRecord c, p->mPoints) {
         writer.writeStartElement("Placemark");
             writer.writeTextElement("name", QString("Plane %1").arg(idx++));
@@ -491,7 +497,9 @@ void KMLCreator::writePlanePlacemarkElement(QXmlStreamWriter &writer, Placemark 
 
             QString desc = descriptionData(p, c);
             if(!desc.isEmpty()) {
-                writer.writeTextElement("description", desc);
+                writer.writeStartElement("description");
+                writer.writeCDATA(desc);
+                writer.writeEndElement(); // description
             }
 
             writer.writeStartElement("Model");
@@ -503,15 +511,21 @@ void KMLCreator::writePlanePlacemarkElement(QXmlStreamWriter &writer, Placemark 
                     writer.writeTextElement("altitude", c.alt());
                 writer.writeEndElement(); // Location
 
-                if(p->mAttitudes.size() > 0) {
-                    Attitude a = p->mAttitudes.at(0);
+                int attitudeSize = p->mAttitudes.size();
+                if(attitudeSize > 0)
+                {
+                    int attitudeIndex = index < attitudeSize ? index : attitudeSize - 1;
 
+                    Attitude a = p->mAttitudes.at(attitudeIndex);
                     QString yaw = (p->mode == "AUTO")? a.navYaw(): a.yaw();
 
                     writer.writeStartElement("Orientation");
-                    writer.writeTextElement("heading", yaw);
-                        writer.writeTextElement("tilt", a.pitch());
-                        writer.writeTextElement("roll", a.roll());
+                        writer.writeTextElement("heading", yaw);
+                        // the sign of tilt and roll has to be changed
+                        QString signChangedPitch = QString::number(a.pitch().toDouble() * -1);
+                        QString signChangedRoll = QString::number(a.roll().toDouble() * -1);
+                        writer.writeTextElement("tilt", signChangedPitch);
+                        writer.writeTextElement("roll", signChangedRoll);
                     writer.writeEndElement(); // Orientation
                 }
 
@@ -528,6 +542,7 @@ void KMLCreator::writePlanePlacemarkElement(QXmlStreamWriter &writer, Placemark 
             writer.writeEndElement(); // Model
 
         writer.writeEndElement(); // Placemark
+        ++index;
     }
 }
 

--- a/src/output/kmlcreator.h
+++ b/src/output/kmlcreator.h
@@ -172,6 +172,8 @@ private:
     QList<CommandedWaypoint> m_waypoints;
     QHash<QString, FormatLine> m_formatLines;
     SummaryData* m_summary;
+
+    bool m_newGPSMessage;
 };
 
 } // namespace kml

--- a/src/ui/AP2DataPlot2D.cpp
+++ b/src/ui/AP2DataPlot2D.cpp
@@ -384,7 +384,7 @@ void AP2DataPlot2D::graphControlsButtonClicked()
                 !i.key().contains(EventMessage::TypeName) &&
                 !i.key().contains(MsgMessage::TypeName))
             {
-                m_axisGroupingDialog->fullAxisUpdate(i.key(),i.value().axis->range().lower,i.value().axis->range().upper,i.value().isManualRange,i.value().isInGroup,i.value().groupName);
+                m_axisGroupingDialog->fullAxisUpdate(i.key(),i.value().axis->range().lower,i.value().axis->range().upper,i.value().isManualRange,i.value().isInGroup,i.value().groupName, i.value().graph->brush().color());
             }
         }
         return;

--- a/src/ui/AP2DataPlotAxisDialog.cc
+++ b/src/ui/AP2DataPlotAxisDialog.cc
@@ -190,7 +190,8 @@ void AP2DataPlotAxisDialog::applyButtonClicked()
             emit graphAddedToGroup(name,group,m_graphScaleMap.value(name));
         }
         graphRangeList.append(graph);
-        graphColorList[name] = ui->graphTableWidget->item(i,0)->backgroundColor();
+        QBrush brush = ui->graphTableWidget->item(i,0)->background();
+        graphColorList[name] = brush.color();
     }
     emit graphGroupingChanged(graphRangeList);
     emit graphColorsChanged(graphColorList);
@@ -358,8 +359,9 @@ void AP2DataPlotAxisDialog::updateAxis(QString name,double lower, double upper)
     }
 }
 
-void AP2DataPlotAxisDialog::fullAxisUpdate(QString name,double lower, double upper,bool ismanual, bool isingroup, QString groupname)
+void AP2DataPlotAxisDialog::fullAxisUpdate(const QString &name, double lower, double upper, bool ismanual, bool isingroup, const QString &groupname, const QColor &color)
 {
+
     if (!m_rangeMap.contains(name))
     {
         m_rangeMap[name] = QPair<double,double>();
@@ -372,13 +374,15 @@ void AP2DataPlotAxisDialog::fullAxisUpdate(QString name,double lower, double upp
         {
             if (ui->graphTableWidget->item(i,1)->text() == name)
             {
+                QBrush brush(color);
+                ui->graphTableWidget->item(i,0)->setBackground(brush);
+
                 QCheckBox *checkbox = qobject_cast<QCheckBox*>(ui->graphTableWidget->cellWidget(i,5));
                 if (checkbox)
                 {
                     if (ismanual)
                     {
                         checkbox->setChecked(false);
-                        return;
                     }
                     else
                     {

--- a/src/ui/AP2DataPlotAxisDialog.h
+++ b/src/ui/AP2DataPlotAxisDialog.h
@@ -32,7 +32,7 @@ public:
     explicit AP2DataPlotAxisDialog(QWidget *parent = 0);
     ~AP2DataPlotAxisDialog();
     void addAxis(QString name,double lower, double upper,QColor color);
-    void fullAxisUpdate(QString name,double lower, double upper,bool ismanual, bool isingroup, QString groupname);
+    void fullAxisUpdate(const QString &name, double lower, double upper, bool ismanual, bool isingroup, const QString &groupname, const QColor &color);
     void updateAxis(QString name,double lower, double upper);
     void removeAxis(QString name);
     void clear();

--- a/src/ui/LogAnalysis.ui
+++ b/src/ui/LogAnalysis.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Graph</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="1">
    <item>
     <widget class="QSplitter" name="horizontalSplitter">
      <property name="orientation">
@@ -41,24 +41,156 @@
          <number>3</number>
         </property>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="20,1">
+         <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,1">
           <property name="spacing">
            <number>2</number>
           </property>
           <item>
-           <layout class="QVBoxLayout" name="verticalLayout_5" stretch="1,1">
-            <property name="spacing">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
+           <layout class="QVBoxLayout" name="verticalLayout_5" stretch="0,1,1">
             <item>
              <widget class="QScrollBar" name="horizontalScrollBar">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
              </widget>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <item>
+               <spacer name="horizontalSpacer_7">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Minimum</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>10</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="modeDisplayCheckBox">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show mode messages&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Show MODE</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="errDisplayCheckBox">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show error messages&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Show ERR</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="evDisplayCheckBox">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show event messages&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Show EV</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="msgDisplayCheckBox">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show Info messages&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Show MSG</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_8">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="showValuesCheckBox">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show value tooltip including the range cursor values when mouse is over plot area.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Show Values Under Mouse</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="tableCursorCheckBox">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Shows a cursor which is linked with the table view. If you select a table line the cursor will jump to this location in the graph and if you drag and drop the cursor the table view will jump to the corresponding line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Show Table Cursor</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="rangeCursorCheckBox">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds a cursor pair to the plot area. Both of them can be moved by drag an drop. The value tool tip will show additional measurements like min,max... for the area between the cursors.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Show Range Cursor</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_9">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="indexTypeCheckBox">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;switches the horizontal (X) Axis from index to time.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Use time on x-axis</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_41">
@@ -82,42 +214,84 @@
                </spacer>
               </item>
               <item>
-               <widget class="QCheckBox" name="modeDisplayCheckBox">
-                <property name="text">
-                 <string>Show MODE</string>
+               <widget class="QPushButton" name="graphControlsPushButton">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Advanced scaling options like setting manual Y-Axis ranges and graph grouping&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
-                <property name="checked">
-                 <bool>true</bool>
+                <property name="text">
+                 <string>Advanced Scaling</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QCheckBox" name="errDisplayCheckBox">
-                <property name="text">
-                 <string>Show ERR</string>
+               <widget class="QPushButton" name="resetScalingPushButton">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Resets all Y-Axis scalings to fit the whole graph&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
-                <property name="checked">
-                 <bool>true</bool>
+                <property name="text">
+                 <string>Reset Scaling</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QCheckBox" name="evDisplayCheckBox">
-                <property name="text">
-                 <string>Show EV</string>
+               <spacer name="horizontalSpacer_4">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
                 </property>
-                <property name="checked">
-                 <bool>true</bool>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Minimum</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QPushButton" name="storeGraphSettingsButton">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Saves the currently enabled graphs with their scaling. The saved view is automagically shared between all open analysis windows.&lt;/p&gt;&lt;p&gt;Saving a new setting overwrites the old one.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Save View</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QCheckBox" name="msgDisplayCheckBox">
-                <property name="text">
-                 <string>Show MSG</string>
+               <widget class="QPushButton" name="applyGraphSettingsButton">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Applys a previous saved view (all enabled graphs and their scaling) to the current analysis window replacing the content.&lt;/p&gt;&lt;p&gt;As all analysis windows share the saved view data this can be used to copy the current settings into another window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
-                <property name="checked">
-                 <bool>true</bool>
+                <property name="text">
+                 <string>Apply View</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Minimum</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QPushButton" name="storeToPresetPushBtn">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adds the current enabled graphs with their settings to the Analyzing Presets menue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Add View To Preset</string>
                 </property>
                </widget>
               </item>
@@ -134,19 +308,6 @@
                 </property>
                </spacer>
               </item>
-              <item>
-               <widget class="QCheckBox" name="indexTypeCheckBox">
-                <property name="toolTip">
-                 <string extracomment="Switches between index or time on x axis"/>
-                </property>
-                <property name="toolTipDuration">
-                 <number>3</number>
-                </property>
-                <property name="text">
-                 <string>Use time on x-axis</string>
-                </property>
-               </widget>
-              </item>
              </layout>
             </item>
            </layout>
@@ -160,12 +321,12 @@
              <widget class="QLabel" name="label">
               <property name="maximumSize">
                <size>
-                <width>20</width>
-                <height>40</height>
+                <width>15</width>
+                <height>25</height>
                </size>
               </property>
               <property name="text">
-               <string>&lt;h1&gt;+&lt;/h1&gt;</string>
+               <string>&lt;h2&gt;+&lt;/h2&gt;</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignCenter</set>
@@ -189,12 +350,12 @@
              <widget class="QLabel" name="label_2">
               <property name="maximumSize">
                <size>
-                <width>20</width>
-                <height>40</height>
+                <width>15</width>
+                <height>45</height>
                </size>
               </property>
               <property name="text">
-               <string>&lt;h1&gt;-&lt;/h1&gt;</string>
+               <string>&lt;h2&gt;-&lt;/h2&gt;</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignCenter</set>
@@ -208,7 +369,7 @@
        </layout>
       </widget>
       <widget class="QWidget" name="layoutWidget">
-       <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="5,1">
+       <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="4,1,0">
         <item>
          <widget class="QTableView" name="tableWidget"/>
         </item>
@@ -287,6 +448,36 @@
           </layout>
          </widget>
         </item>
+        <item>
+         <widget class="QPushButton" name="filterShowPushButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>25</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>T
+a
+b
+l
+e
+ 
+F
+i
+l
+t
+e
+r</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </widget>
@@ -299,98 +490,6 @@
       </property>
      </widget>
     </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <spacer name="horizontalSpacer_6">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>10</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="exportLogButton">
-       <property name="text">
-        <string>Export log</string>
-       </property>
-       <property name="shortcut">
-        <string>Ctrl+S</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="exportKmlButton">
-       <property name="text">
-        <string>Export Kml</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="graphControlsPushButton">
-       <property name="text">
-        <string>Advanced Scaling</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="resetScalingPushButton">
-       <property name="text">
-        <string>Reset Scaling</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="filterShowPushButton">
-       <property name="text">
-        <string>Table Filter</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="showValuesCheckBox">
-       <property name="text">
-        <string>Show Values Under Mouse</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="tableCursorCheckBox">
-       <property name="text">
-        <string>Show Table Cursor</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="rangeCursorCheckBox">
-       <property name="text">
-        <string>Show Range Cursor</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>

--- a/src/ui/Loghandling/LogAnalysis.cpp
+++ b/src/ui/Loghandling/LogAnalysis.cpp
@@ -32,6 +32,7 @@ This file is part of the APM_PLANNER project
 
 #include "ArduPilotMegaMAV.h"
 #include "Loghandling/LogExporter.h"
+#include "Loghandling/PresetManager.h"
 
 
 
@@ -42,7 +43,7 @@ LogAnalysisCursor::LogAnalysisCursor(QCustomPlot *parentPlot, double xPosition, 
     m_type(type),
     mp_otherCursor(0)
 {
-    QLOG_DEBUG() << "LogAnalysisCursor::LogAnalysisCursor - CTOR - type " << type;
+    QLOG_TRACE() << "LogAnalysisCursor::LogAnalysisCursor - CTOR - type " << type;
     point1->setCoords(m_currentPos, 1);
     point2->setCoords(m_currentPos, 0);
     setSelectable(true);
@@ -51,7 +52,7 @@ LogAnalysisCursor::LogAnalysisCursor(QCustomPlot *parentPlot, double xPosition, 
 
 LogAnalysisCursor::~LogAnalysisCursor()
 {
-    QLOG_DEBUG() << "LogAnalysisCursor::~LogAnalysisCursor - DTOR - type " << m_type;
+    QLOG_TRACE() << "LogAnalysisCursor::~LogAnalysisCursor - DTOR - type " << m_type;
 }
 
 void LogAnalysisCursor::setOtherCursor(LogAnalysisCursor *pCursor)
@@ -159,12 +160,12 @@ void LogAnalysisCursor::wheelEvent(QWheelEvent *event)
 
 LogAnalysisAxis::LogAnalysisAxis(QCPAxisRect *axisRect, AxisType type) : QCPAxis(axisRect, type)
 {
-    QLOG_DEBUG() << "LogAnalysisAxis::LogAnalysisAxis - CTOR";
+    QLOG_TRACE() << "LogAnalysisAxis::LogAnalysisAxis - CTOR";
 }
 
 LogAnalysisAxis::~LogAnalysisAxis()
 {
-    QLOG_DEBUG() << "LogAnalysisAxis::~LogAnalysisAxis - DTOR";
+    QLOG_TRACE() << "LogAnalysisAxis::~LogAnalysisAxis - DTOR";
 }
 
 void LogAnalysisAxis::wheelEvent(QWheelEvent *event)
@@ -211,6 +212,24 @@ LogAnalysis::LogAnalysis(QWidget *parent) :
 {
     QLOG_DEBUG() << "LogAnalysis::LogAnalysis - CTOR";
     ui.setupUi(this);
+
+    // add menu bar
+    m_menuBarPtr.reset(new QMenuBar(this));
+    QMenu *exportMenu = new QMenu("Export...", this);
+    m_menuBarPtr->addMenu(exportMenu);
+    // add ascii export to menu
+    QAction *p_Action = exportMenu->addAction("Export to Ascii log file");
+    connect(p_Action, SIGNAL(triggered()), this, SLOT(exportAsciiLogClicked()));
+    // add KMZ export to menu
+    p_Action = exportMenu->addAction("Export to KML/KMZ file");
+    connect(p_Action, SIGNAL(triggered()), this, SLOT(exportKmlClicked()));
+
+    // create preset menu and give it to preset manager
+    m_presetMgrPtr.reset(new PresetManager(this, m_menuBarPtr.data()));
+    connect(m_presetMgrPtr.data(), SIGNAL(newPresetSelected(PresetManager::presetElementVec)), this, SLOT(analysisPresetSelected(PresetManager::presetElementVec)));
+
+    // add menubar to window
+    layout()->setMenuBar(m_menuBarPtr.data());
 
     // create QCustomPlot
     m_plotPtr.reset(new QCustomPlot(ui.widget));
@@ -280,6 +299,7 @@ LogAnalysis::LogAnalysis(QWidget *parent) :
     m_axisGroupingDialog.reset(new AP2DataPlotAxisDialog());
     m_axisGroupingDialog->hide();
     connect(m_axisGroupingDialog.data(), SIGNAL(graphGroupingChanged(QList<AP2DataPlotAxisDialog::GraphRange>)), this, SLOT(graphGroupingChanged(QList<AP2DataPlotAxisDialog::GraphRange>)));
+    connect(m_axisGroupingDialog.data(), SIGNAL(graphColorsChanged(QMap<QString,QColor>)), this, SLOT(graphColorsChanged(QMap<QString,QColor>)));
 
     // setup policy and connect slot for context menu popup
     m_plotPtr->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -303,13 +323,16 @@ LogAnalysis::LogAnalysis(QWidget *parent) :
     connect(ui.filterSelectAllPushButton,SIGNAL(clicked()),this,SLOT(filterSelectAllClicked()));
     connect(ui.filterInvertSelectPushButton,SIGNAL(clicked()),this,SLOT(filterSelectInvertClicked()));
 
-    connect(ui.exportLogButton, SIGNAL(clicked()), this, SLOT(exportAsciiLogClicked()));
-    connect(ui.exportKmlButton, SIGNAL(clicked()), this, SLOT(exportKmlClicked()));
     connect(ui.graphControlsPushButton, SIGNAL(clicked()), this, SLOT(graphControlsButtonClicked()));
     connect(ui.resetScalingPushButton, SIGNAL(clicked()), this, SLOT(resetValueScaling()));
-    connect(ui.splitter, SIGNAL(splitterMoved(int, int)), this, SLOT(tableSplitterMoved(int, int)));
+
+    connect(ui.storeGraphSettingsButton, SIGNAL(clicked()), this, SLOT(storeGraphSettingsPressed()));
+    connect(ui.applyGraphSettingsButton, SIGNAL(clicked()), this, SLOT(applyGraphSettingsPressed()));
+    connect(ui.storeToPresetPushBtn, SIGNAL(clicked()), this, SLOT(addCurrentViewToPreset()));
 
     loadSettings();
+
+    setStyleSheet("QToolTip {background: #ffffdf}");
 }
 
 LogAnalysis::~LogAnalysis()
@@ -324,7 +347,8 @@ void LogAnalysis::loadLog(QString filename)
     m_filename = filename;
     // setup window name
     QString shortfilename = filename.mid(filename.lastIndexOf("/")+1);
-    setWindowTitle(tr("Graph: %1").arg(shortfilename));
+    QString presetName = m_presetMgrPtr->getFileInfo().fileName();
+    setWindowTitle(tr("Graph: %1 [%2]").arg(shortfilename).arg(presetName));
 
     // create datastorage, loader thread and connect the signals
     m_dataStoragePtr = LogdataStorage::Ptr(new LogdataStorage());
@@ -412,13 +436,15 @@ void LogAnalysis::cursorRangeChange()
 {
     if(mp_cursorLeft && mp_cursorRight)
     {
+        // get cursor positions and range
         m_rangeValuesStorage.clear();
         double leftPos  = mp_cursorLeft->getCurrentXPos();
         double rightPos = mp_cursorRight->getCurrentXPos();
 
         m_cursorXAxisRange = rightPos - leftPos;
 
-        QHash<QString, GraphElements>::Iterator iter;
+        // Calculate range values for every active graph
+        activeGraphType::Iterator iter;
         for(iter = m_activeGraphs.begin(); iter != m_activeGraphs.end(); ++iter)
         {
             QSharedPointer<QCPGraphDataContainer> dataPtr = iter->p_graph->data();
@@ -567,6 +593,7 @@ void LogAnalysis::loadSettings()
     ui.evDisplayCheckBox->setChecked(settings.value("SHOW_EV", Qt::Checked).toBool());
     ui.msgDisplayCheckBox->setChecked(settings.value("SHOW_MSG", Qt::Checked).toBool());
     ui.showValuesCheckBox->setChecked(settings.value("SHOW_VALUES", Qt::Unchecked).toBool());
+    m_presetMgrPtr->setFileName(settings.value("PRESET_FILE").toString());
     settings.endGroup();
 }
 
@@ -579,7 +606,54 @@ void LogAnalysis::saveSettings()
     settings.setValue("SHOW_EV", ui.evDisplayCheckBox->isChecked());
     settings.setValue("SHOW_MSG", ui.msgDisplayCheckBox->isChecked());
     settings.setValue("SHOW_VALUES", ui.showValuesCheckBox->isChecked());
+
+    QFileInfo fileInfo = m_presetMgrPtr->getFileInfo();
+    QString filePath;
+    if(!fileInfo.fileName().isEmpty())  // if fileName is empty absoluteFilePath() delivers unpredicted values
+    {
+        filePath = fileInfo.absoluteFilePath();
+    }
+    settings.setValue("PRESET_FILE", filePath);
     settings.endGroup();
+}
+
+QList<AP2DataPlotAxisDialog::GraphRange> LogAnalysis::presetToRangeConverter(const PresetManager::presetElementVec &preset)
+{
+    QList<AP2DataPlotAxisDialog::GraphRange> graphRanges;
+
+    for(int i = 0; i < preset.size(); ++i)
+    {
+        if(m_activeGraphs.contains(preset.at(i).m_graph))    // the element is enabled?
+        {
+            GraphElements &element = m_activeGraphs[preset.at(i).m_graph];
+            element.p_graph->setPen(QPen(preset.at(i).m_color, 1));
+            element.p_yAxis->setLabelColor(preset.at(i).m_color);
+            element.p_yAxis->setTickLabelColor(preset.at(i).m_color);
+
+            AP2DataPlotAxisDialog::GraphRange range;
+            range.graph = preset.at(i).m_graph;
+            if(preset.at(i).m_manualRange)
+            {
+                range.manual = true;
+                range.max = preset.at(i).m_range.upper;
+                range.min = preset.at(i).m_range.lower;
+            }
+            else if(preset.at(i).m_group.size() > 0)
+            {
+                range.isgrouped = true;
+                range.group = preset.at(i).m_group;
+                range.max = element.p_yAxis->range().upper; // As the graph is already autoscaled (done when enabling) we just use the autoscaled min / max.
+                range.min = element.p_yAxis->range().lower;
+            }
+
+            graphRanges.push_back(range);
+        }
+        else
+        {
+            QLOG_WARN() << "The graph " << preset.at(i).m_graph << " was not found! Could not apply settings.";
+        }
+    }
+    return graphRanges;
 }
 
 void LogAnalysis::hideTableView(bool hide)
@@ -708,7 +782,7 @@ void LogAnalysis::logLoadingDone(AP2DataPlotStatus status)
     // create an invisible y-axis for the text arrows
     m_arrowGraph.p_yAxis = m_plotPtr->axisRect()->addAxis(QCPAxis::atLeft);
     m_arrowGraph.p_yAxis->setVisible(false);
-    m_arrowGraph.p_yAxis->setRangeUpper(8.0);
+    m_arrowGraph.p_yAxis->setRangeUpper(s_TextArrowPositions + 1);  // The last text shall not be on upper border (+1)
     // Load MODE, ERR, EV, MSG messages from datamodel
     m_dataStoragePtr->getMessagesOfType(ModeMessage::TypeName, m_indexToMessageMap);
     m_dataStoragePtr->getMessagesOfType(ErrorMessage::TypeName, m_indexToMessageMap);
@@ -1124,10 +1198,11 @@ void LogAnalysis::exportDialogAccepted()
 
 void LogAnalysis::graphControlsButtonClicked()
 {
-    QHash<QString, GraphElements>::const_iterator iter;
+    activeGraphType::const_iterator iter;
     for (iter = m_activeGraphs.constBegin(); iter != m_activeGraphs.constEnd() ; ++iter)
     {
-        m_axisGroupingDialog->fullAxisUpdate(iter.key(), iter.value().p_yAxis->range().lower, iter.value().p_yAxis->range().upper, iter.value().m_manualRange, iter.value().m_inGroup, iter.value().m_groupName);
+        m_axisGroupingDialog->fullAxisUpdate(iter.key(), iter->p_yAxis->range().lower, iter->p_yAxis->range().upper,
+                                             iter->m_manualRange, iter->m_inGroup, iter->m_groupName, iter->p_graph->pen().color());
     }
 
     m_axisGroupingDialog->show();
@@ -1138,7 +1213,7 @@ void LogAnalysis::graphControlsButtonClicked()
 void LogAnalysis::graphGroupingChanged(QList<AP2DataPlotAxisDialog::GraphRange> graphRangeList)
 {
     // first reset all active elements to their default state
-    QHash<QString, GraphElements>::iterator iter;
+    activeGraphType::iterator iter;
     for (iter = m_activeGraphs.begin(); iter != m_activeGraphs.end() ; ++iter)
     {
         if(iter->m_inGroup || iter->m_manualRange)
@@ -1157,7 +1232,7 @@ void LogAnalysis::graphGroupingChanged(QList<AP2DataPlotAxisDialog::GraphRange> 
     {
         if(range.isgrouped)
         {
-            GroupElement &groupElement = groupingMap[range.group];
+            GroupElement &groupElement = groupingMap[range.group];  // yes, if doesn't exist just create a new one.
             groupElement.m_groupName = range.group;
             groupElement.m_upper = groupElement.m_upper < range.max ? range.max : groupElement.m_upper;
             groupElement.m_lower = groupElement.m_lower > range.min ? range.min : groupElement.m_lower;
@@ -1200,6 +1275,23 @@ void LogAnalysis::graphGroupingChanged(QList<AP2DataPlotAxisDialog::GraphRange> 
     m_plotPtr->replot();
 }
 
+void LogAnalysis::graphColorsChanged(QMap<QString,QColor> colorlist)
+{
+    QMap<QString,QColor>::ConstIterator iter;
+    for(iter = colorlist.constBegin(); iter != colorlist.constEnd(); ++iter)
+    {
+        if(m_activeGraphs.contains(iter.key()))
+        {
+            GraphElements &element = m_activeGraphs[iter.key()];
+            element.p_graph->setPen(QPen(*iter, 1));
+            element.p_yAxis->setLabelColor(*iter);
+            element.p_yAxis->setTickLabelColor(*iter);
+        }
+    }
+
+    m_plotPtr->replot();
+}
+
 void LogAnalysis::plotMouseMove(QMouseEvent *evt)
 {
     bool insideCursorRange = false;
@@ -1232,7 +1324,7 @@ void LogAnalysis::plotMouseMove(QMouseEvent *evt)
 
     // and now the data of all enabled graphs
     outStream.setRealNumberNotation(QTextStream::FixedNotation);
-    QHash<QString, GraphElements>::Iterator iter;
+    activeGraphType::Iterator iter;
     for(iter = m_activeGraphs.begin(); iter != m_activeGraphs.end(); ++iter)
     {
         outStream.setRealNumberPrecision(3);
@@ -1365,7 +1457,7 @@ void LogAnalysis::removeRangeCursors()
 void LogAnalysis::resetValueScaling()
 {
     // reset all active elements to their default state
-    QHash<QString, GraphElements>::iterator iter;
+    activeGraphType::iterator iter;
     for (iter = m_activeGraphs.begin(); iter != m_activeGraphs.end() ; ++iter)
     {
         if(iter->m_inGroup || iter->m_manualRange)
@@ -1403,26 +1495,111 @@ void LogAnalysis::enableTableCursor(bool enable)
     }
 }
 
-void LogAnalysis::tableSplitterMoved(int pos, int index)
+void LogAnalysis::storeGraphSettingsPressed()
 {
-    Q_UNUSED(pos);
-    Q_UNUSED(index);
+    QLOG_DEBUG() << "LogAnalysis::storeGraphSettingsPressed()";
 
-    if(ui.tableWidget->size().height() > 0) // table view is visible
+    activeGraphType::iterator iter;
+    PresetManager::presetElementVec preset;
+    // iterate all visible graphs and store their setting
+    for(iter = m_activeGraphs.begin(); iter != m_activeGraphs.end(); ++iter)
     {
-        // set the buttons accordingly
-        if(!ui.filterShowPushButton->isEnabled())
-        {
-            ui.filterShowPushButton->setDisabled(false);
+        PresetManager::presetElement element;
+        element.m_graph = iter.key();
+        element.m_color = iter->p_graph->pen().color();
+        if(iter->m_manualRange)
+        {   // y-axis scaling is only stored if graph is in manual range...
+            element.m_manualRange = true;
+            element.m_range = iter->p_yAxis->range();
         }
-    }
-    else
-    {
-        if(ui.filterShowPushButton->isEnabled())
-        {
-            ui.filterShowPushButton->setDisabled(true);
+        else if(iter->m_inGroup)
+        {   //... or in group range
+            element.m_group = iter->m_groupName;
+            element.m_range = iter->p_yAxis->range();
         }
+
+        preset.push_back(element);
     }
+    m_presetMgrPtr->saveSpecialSet(preset, ui.indexTypeCheckBox->isChecked());
 }
 
+void LogAnalysis::applyGraphSettingsPressed()
+{
+    QLOG_DEBUG() << "LogAnalysis::applyGraphSettingsPressed()";
 
+    // get preset from manager
+    PresetManager::presetElementVec preset;
+    bool usesTimeAxis = m_presetMgrPtr->loadSpecialSet(preset);
+
+    // disable all open graphs
+    ui.dataSelectionScreen->disableAllItems();
+    // X-Axis settings
+    ui.indexTypeCheckBox->setChecked(usesTimeAxis);
+    indexTypeCheckBoxClicked(usesTimeAxis);
+
+    // the enabling has to be done in 2 steps.
+    // first enable all graphs stored in the settings.
+    // Second configure then enabled graphs color and range
+
+    // Create list with enabled graphs and enable them
+    QStringList enabledGraphList;
+    for(int i = 0; i < preset.size(); ++i)
+    {
+        enabledGraphList.push_back(preset.at(i).m_graph);
+    }
+    ui.dataSelectionScreen->enableItemList(enabledGraphList);
+
+    // convert preset to ranges and use grouping changed method to scale the graph
+    QList<AP2DataPlotAxisDialog::GraphRange> graphRanges;
+    graphRanges = presetToRangeConverter(preset);
+    graphGroupingChanged(graphRanges);
+}
+
+void LogAnalysis::analysisPresetSelected(PresetManager::presetElementVec preset)
+{
+    QLOG_DEBUG() << "LogAnalysis::analysisPresetSelected()";
+    // first clear the graph
+    ui.dataSelectionScreen->disableAllItems();
+
+    // Create list with enabled graphs and enable them
+    QStringList enabledGraphList;
+    for(int i = 0; i < preset.size(); ++i)
+    {
+        enabledGraphList.push_back(preset.at(i).m_graph);
+    }
+    ui.dataSelectionScreen->enableItemList(enabledGraphList);
+
+    // now set range and color
+    // convert preset to ranges and use grouping changed method to scale the graph
+    QList<AP2DataPlotAxisDialog::GraphRange> graphRanges;
+    graphRanges = presetToRangeConverter(preset);
+    graphGroupingChanged(graphRanges);
+}
+
+void LogAnalysis::addCurrentViewToPreset()
+{
+    QLOG_DEBUG() << "LogAnalysis::addCurrentViewToPreset()";
+
+    activeGraphType::iterator iter;
+    PresetManager::presetElementVec preset;
+    for(iter = m_activeGraphs.begin(); iter != m_activeGraphs.end(); ++iter)
+    {
+        PresetManager::presetElement element;
+        element.m_graph = iter.key();
+        element.m_color = iter->p_graph->pen().color();
+        if(iter->m_manualRange)
+        {   // y-axis scaling is only stored if graph is in manual range...
+            element.m_manualRange = true;
+            element.m_range = iter->p_yAxis->range();
+        }
+        else if(iter->m_inGroup)
+        {   //... or in group range
+            element.m_group = iter->m_groupName;
+            element.m_range = iter->p_yAxis->range();
+        }
+
+        preset.push_back(element);
+    }
+
+    m_presetMgrPtr->addToCurrentPresets(preset);
+}

--- a/src/ui/Loghandling/PresetManager.cpp
+++ b/src/ui/Loghandling/PresetManager.cpp
@@ -1,0 +1,474 @@
+/*===================================================================
+APM_PLANNER Open Source Ground Control Station
+
+(c) 2017 APM_PLANNER PROJECT <http://www.ardupilot.com>
+
+This file is part of the APM_PLANNER project
+
+    APM_PLANNER is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    APM_PLANNER is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with APM_PLANNER. If not, see <http://www.gnu.org/licenses/>.
+
+======================================================================*/
+/**
+ * @file PresetManager.cpp
+ * @author Arne Wischmann <wischmann-a@gmx.de>
+ * @date 13 Apr 2017
+ * @brief File providing implementation for the Preset manager class
+ */
+
+#include <QFileDialog>
+#include <QSettings>
+
+#include "PresetManager.h"
+#include "logging.h"
+#include "configuration.h"
+
+
+PresetManager::PresetManager(QWidget *p_parent, QMenuBar *p_menuBar) :
+    QObject (p_parent),
+    mp_menu(0),
+    m_presetHasChanged(false)
+{
+    QLOG_DEBUG() << "PresetManager::PresetManager - CTOR";
+
+    qRegisterMetaType<PresetManager::presetElementVec>("PresetManager::presetElementVec");
+
+    // create own menu and add the management items
+    mp_menu = new QMenu("Analyzing Presets", p_parent);
+    p_menuBar->addMenu(mp_menu);
+
+    QAction *p_Action = mp_menu->addAction("Load Presets");
+    connect(p_Action, SIGNAL(triggered()), this, SLOT(loadPresets()));
+    p_Action = mp_menu->addAction("Save Presets");
+    connect(p_Action, SIGNAL(triggered()), this, SLOT(savePresetCheckingFilename()));
+    p_Action = mp_menu->addAction("Save Presets as");
+    connect(p_Action, SIGNAL(triggered()), this, SLOT(savePresetsAs()));
+    p_Action = mp_menu->addAction("Remove current Preset");
+    connect(p_Action, SIGNAL(triggered()), this, SLOT(removePresets()));
+    p_Action = mp_menu->addAction("Remove all Presets");
+    connect(p_Action, SIGNAL(triggered()), this, SLOT(removeAllPresets()));
+
+    mp_menu->addSeparator();
+}
+
+PresetManager::~PresetManager()
+{
+    QLOG_DEBUG() << "PresetManager::~PresetManager - DTOR";
+    checkAndSaveIfPresetModified();
+}
+
+QFileInfo PresetManager::getFileInfo() const
+{
+    return m_presetFile;
+}
+
+void PresetManager::setFileName(const QString &fileName)
+{
+    if(!fileName.isEmpty())
+    {
+        m_presetFile.setFile(fileName);
+        readPresetFile();
+    }
+}
+
+PresetManager::presetElementVec PresetManager::getSelectedPreset() const
+{
+    return m_currentPreset.m_enabledGraphs;
+}
+
+void PresetManager::saveSpecialSet(const presetElementVec &preset, bool usesTimeAxis) const
+{
+    // This preset is stored in the APM Planner ini file and loaded / stored on every
+    // access. This guarantees that a saved set is immediate loadable from another analysis window.
+    QSettings graphSettings;
+    graphSettings.beginGroup("LOGANALYSIS");
+
+    graphSettings.beginWriteArray("GRAPH_ELEMENTS");
+    for(int i = 0; i < preset.size(); ++i)
+    {
+        graphSettings.setArrayIndex(i);
+        graphSettings.setValue("NAME", preset.at(i).m_graph);
+        graphSettings.setValue("COLOR/RED", preset.at(i).m_color.red());
+        graphSettings.setValue("COLOR/GREEN", preset.at(i).m_color.green());
+        graphSettings.setValue("COLOR/BLUE", preset.at(i).m_color.blue());
+        if(preset.at(i).m_manualRange)
+        {   // only store scaling if set to manual
+            graphSettings.setValue("Y_AXIS_MIN", preset.at(i).m_range.lower);
+            graphSettings.setValue("Y_AXIS_MAX", preset.at(i).m_range.upper);
+        }
+        else if(preset.at(i).m_group.size() > 0)
+        {   // store group name if grouped
+            graphSettings.setValue("GROUP", preset.at(i).m_group);
+        }
+    }
+    graphSettings.endArray();
+
+    graphSettings.beginGroup("GRAPH_SETTINGS");
+    graphSettings.setValue("TIME_AXIS", usesTimeAxis);
+    graphSettings.endGroup();
+
+    graphSettings.endGroup();   // "LOGANALYSIS"
+
+    graphSettings.sync();
+    QLOG_DEBUG() << "PresetManager::saveSpecialSet - Special View saved.";
+
+}
+
+bool PresetManager::loadSpecialSet(presetElementVec &preset) const
+{
+    // This preset is stored in the APM Planner ini file and loaded / stored on every
+    // access. This guarantees that a saved set is immediate loadable from another analysis window.
+
+    // Load X-Axis settings
+    QSettings graphSettings;
+    graphSettings.beginGroup("LOGANALYSIS");
+    graphSettings.beginGroup("GRAPH_SETTINGS");
+    bool usesTimeAxis = graphSettings.value("TIME_AXIS", Qt::Checked).toBool();
+    graphSettings.endGroup();   // "GRAPH_SETTINGS"
+
+    // now load the enabled graphs
+    int size = graphSettings.beginReadArray("GRAPH_ELEMENTS");
+    for(int i = 0; i < size; ++i)
+    {
+        graphSettings.setArrayIndex(i);
+        presetElement element;
+        element.m_graph = graphSettings.value("NAME").toString();
+
+        int red   = graphSettings.value("COLOR/RED").toInt();
+        int green = graphSettings.value("COLOR/GREEN").toInt();
+        int blue  = graphSettings.value("COLOR/BLUE").toInt();
+        QColor color(red, green, blue);
+        element.m_color = color;
+        if(graphSettings.contains("GROUP"))
+        {
+            element.m_group = graphSettings.value("GROUP").toString();
+        }
+        else if(graphSettings.contains("Y_AXIS_MIN") && graphSettings.contains("Y_AXIS_MAX"))
+        {
+            QCPRange yAxisRange(graphSettings.value("Y_AXIS_MIN").toDouble(), graphSettings.value("Y_AXIS_MAX").toDouble());
+            element.m_range = yAxisRange;
+            element.m_manualRange = true;
+        }
+        preset.push_back(element);
+    }
+    graphSettings.endArray();   // "GRAPH_ELEMENTS"
+
+    graphSettings.endGroup();   // "LOGANALYSIS"
+
+    QLOG_DEBUG() << "PresetManager::loadSpecialSet - Special View loaded.";
+
+    return usesTimeAxis;
+}
+
+void PresetManager::addToCurrentPresets(const presetElementVec &preset)
+{
+    bool ok = false;
+    QString name = QInputDialog::getText(qobject_cast<QWidget*>(parent()), tr("Enter Preset Name"), tr("Preset Name:"), QLineEdit::Normal,
+                                         "", &ok);
+    if (ok && !name.isEmpty())
+    {
+        if(!m_NameToPresetMap.contains(name))
+        {
+            presetData internalPreset;
+            internalPreset.m_presetName = name;
+            internalPreset.mp_menuAction = mp_menu->addAction(name);
+            internalPreset.m_enabledGraphs = preset;
+            m_NameToPresetMap.insert(name, internalPreset);
+            connect(internalPreset.mp_menuAction, SIGNAL(triggered()), this, SLOT(handlePresetSelected()));
+            QLOG_DEBUG() << "PresetManager::addSavedView() - added " << name << " preset";
+        }
+        else
+        {
+            QLOG_DEBUG() << "PresetManager::addSavedView() - preset " << name << "already available";
+        }
+    }
+    m_presetHasChanged = true;
+}
+
+void PresetManager::readPresetFile()
+{
+    // first remove all loaded presets
+    removeAllPresets();
+    QSettings presets(m_presetFile.absoluteFilePath(), QSettings::IniFormat);
+    presets.beginGroup("GRAPHING_PRESETS");
+
+    if(presets.contains(("PRESET_FILE_VERSION")))
+    {
+        QString presetVersion = presets.value("PRESET_FILE_VERSION").toString();
+
+        if(presetVersion == "1.0")
+        {
+            readPresetFileVersion10(presets);
+        }
+        // Add new preset versions here!
+        else
+        {
+            QLOG_ERROR() << "Could not load preset file " << m_presetFile.absoluteFilePath() << ". Unknown Version:" << presetVersion;
+            m_presetFile = QFileInfo();
+        }
+    }
+    else
+    {
+        QLOG_WARN() << "PresetManager::readPresetFile() - ini file has no version string - not loaded";
+        m_presetFile = QFileInfo();
+    }
+
+    presets.endGroup(); // "GRAPHING_PRESETS"
+
+    m_presetHasChanged = false;    // a fresh loaded preset has not changed
+    adaptWindowTitle();
+}
+
+void PresetManager::readPresetFileVersion10(QSettings &presets)
+{
+    // "GRAPHING_PRESETS" group is handeled by caller
+    // check if valid - at least there must be one name
+    if(!presets.contains("SETNAMES/1/NAME"))
+    {
+        QLOG_WARN() << "PresetManager::readPresetFile() - ini file seems to be corrupt - not loaded";
+        m_presetFile = QFileInfo();
+        return;
+    }
+
+    // first fetch the names of all presets
+    int size = presets.beginReadArray("SETNAMES");
+    for(int i = 0; i < size; ++i)
+    {
+        presets.setArrayIndex(i);
+        QString name = presets.value("NAME").toString();
+        if(!m_NameToPresetMap.contains(name))
+        {
+            presetData internalPreset;
+            internalPreset.m_presetName = name;
+            internalPreset.mp_menuAction = mp_menu->addAction(name);
+            m_NameToPresetMap.insert(name, internalPreset);
+            connect(internalPreset.mp_menuAction, SIGNAL(triggered()), this, SLOT(handlePresetSelected()));
+            QLOG_DEBUG() << "PresetManager::loadDialogAccepted() - added " << name << " preset";
+        }
+        else
+        {
+            QLOG_DEBUG() << "PresetManager::loadDialogAccepted() - preset " << name << "already loaded";
+        }
+    }
+    presets.endArray();
+
+    // now get the content of the presets
+    QMap<QString, presetData>::Iterator iter;
+    for(iter = m_NameToPresetMap.begin(); iter != m_NameToPresetMap.end(); ++iter)
+    {
+        size = presets.beginReadArray(iter->m_presetName);
+        for(int i = 0; i < size; ++i)
+        {
+            presets.setArrayIndex(i);
+            presetElement element;
+
+            element.m_graph = presets.value("NAME").toString();
+            int red      = presets.value("COLOR/RED").toInt();
+            int green    = presets.value("COLOR/GREEN").toInt();
+            int blue     = presets.value("COLOR/BLUE").toInt();
+            QColor color(red, green, blue);
+            element.m_color = color;
+            if(presets.contains("GROUP"))   // is optional
+            {
+                element.m_group = presets.value("GROUP").toString();
+            }
+            else if(presets.contains("Y_AXIS_MIN") && presets.contains("Y_AXIS_MAX"))   // is optional
+            {
+                QCPRange yAxisRange(presets.value("Y_AXIS_MIN").toDouble(), presets.value("Y_AXIS_MAX").toDouble());
+                element.m_range = yAxisRange;
+                element.m_manualRange = true;
+            }
+            iter->m_enabledGraphs.push_back(element);
+        }
+        presets.endArray();
+    }
+}
+
+void PresetManager::checkAndSaveIfPresetModified()
+{
+    if(m_presetHasChanged)
+    {
+        QMessageBox msgBox;
+        msgBox.setText("The presets have been modified.");
+        msgBox.setInformativeText("Do you want to save your changes?");
+        QPushButton *saveButton = msgBox.addButton(tr(" Save "), QMessageBox::ActionRole);
+        QPushButton *saveAsButton = msgBox.addButton(tr(" Save As "), QMessageBox::ActionRole);
+        QPushButton *discardButton = msgBox.addButton(tr(" Discard "), QMessageBox::DestructiveRole);
+        msgBox.exec();
+
+        if(msgBox.clickedButton() == saveButton)
+            savePresetCheckingFilename();
+        else if(msgBox.clickedButton() == saveAsButton)
+            savePresetsAs();
+        else if(msgBox.clickedButton() == discardButton)
+            QLOG_INFO() << "PresetManager::~PresetManager - Changed preset discarded";
+    }
+}
+
+void PresetManager::adaptWindowTitle() const
+{
+    QWidget *window = qobject_cast<QWidget*>(parent());
+
+    if(window)
+    {
+        QString title = window->windowTitle();
+
+        int index = title.lastIndexOf('[');
+        if(index > 0)
+        {
+            title.truncate(index - 1);   // If found just remove one more getting the space before '[' (see next lines)
+        }
+        title.append(" [");
+        title.append(m_presetFile.fileName());     // now add the preset filename to window title
+        title.append(']');
+
+        window->setWindowTitle(title);
+    }
+}
+
+void PresetManager::loadPresets()
+{
+    checkAndSaveIfPresetModified();
+
+    QFileDialog *dialog = new QFileDialog(qobject_cast<QWidget*>(parent()), "Load Analyzing Presets", QGC::appDataDirectory(), "Analyzing Presets (*.ini);;All Files (*.*)");
+    dialog->setFileMode(QFileDialog::ExistingFile);
+    dialog->open(this, SLOT(loadDialogAccepted()));
+}
+
+void PresetManager::loadDialogAccepted()
+{
+    QFileDialog *dialog = qobject_cast<QFileDialog*>(sender());
+    if (!dialog || (dialog->selectedFiles().size() == 0))
+    {
+        return;
+    }
+    m_presetFile.setFile(dialog->selectedFiles().first());
+    dialog->deleteLater();
+
+    // read presets
+    readPresetFile();
+}
+
+void PresetManager::handlePresetSelected()
+{
+    QAction *triggeredAction = qobject_cast<QAction*>(sender());
+    QString presetName = triggeredAction->text();
+    QLOG_DEBUG() << "PresetManager::handlePresetSelected() - preset:" << presetName;
+
+    if(m_NameToPresetMap.contains(presetName))
+    {
+        m_currentPreset = m_NameToPresetMap.value(presetName);
+        emit newPresetSelected(m_currentPreset.m_enabledGraphs);
+    }
+}
+
+void PresetManager::removeAllPresets()
+{
+    foreach(const presetData &preset, m_NameToPresetMap)
+    {
+        mp_menu->removeAction(preset.mp_menuAction);
+    }
+    m_NameToPresetMap.clear();
+    m_presetHasChanged = true;
+}
+
+void PresetManager::savePresetCheckingFilename()
+{
+    if(!m_presetFile.fileName().isEmpty())
+        savePresets();
+    else
+        savePresetsAs();
+}
+
+void PresetManager::savePresets()
+{
+    QSettings graphPresets(m_presetFile.absoluteFilePath(), QSettings::IniFormat);
+    graphPresets.clear();
+    graphPresets.beginGroup("GRAPHING_PRESETS");
+
+    graphPresets.setValue("PRESET_FILE_VERSION", "1.0");
+
+    // create the names of the presets
+    graphPresets.beginWriteArray("SETNAMES");
+    int index = 0;
+    QMap<QString, presetData>::iterator iter;
+    for(iter = m_NameToPresetMap.begin(); iter != m_NameToPresetMap.end(); ++iter)
+    {
+        graphPresets.setArrayIndex(index++);
+        graphPresets.setValue("NAME", iter->m_presetName);
+    }
+    graphPresets.endArray();
+
+    // store the preset data itself
+    for(iter = m_NameToPresetMap.begin(); iter != m_NameToPresetMap.end(); ++iter)
+    {
+        graphPresets.beginWriteArray(iter->m_presetName);
+        for(int i = 0; i < iter->m_enabledGraphs.size(); ++i)
+        {
+            graphPresets.setArrayIndex(i);
+            graphPresets.setValue("NAME", iter->m_enabledGraphs.at(i).m_graph);
+            graphPresets.setValue("COLOR/RED", iter->m_enabledGraphs.at(i).m_color.red());
+            graphPresets.setValue("COLOR/GREEN", iter->m_enabledGraphs.at(i).m_color.green());
+            graphPresets.setValue("COLOR/BLUE", iter->m_enabledGraphs.at(i).m_color.blue());
+            if(iter->m_enabledGraphs.at(i).m_group.size() > 0)
+            {
+                graphPresets.setValue("GROUP", iter->m_enabledGraphs.at(i).m_group);
+            }
+            else if(iter->m_enabledGraphs.at(i).m_manualRange)
+            {
+                graphPresets.setValue("Y_AXIS_MIN", iter->m_enabledGraphs.at(i).m_range.lower);
+                graphPresets.setValue("Y_AXIS_MAX", iter->m_enabledGraphs.at(i).m_range.upper);
+            }
+        }
+        graphPresets.endArray();
+    }
+
+    graphPresets.endGroup(); //"GRAPHING_PRESETS"
+
+    graphPresets.sync();
+    QLOG_DEBUG() << "All presets saved to " << m_presetFile.absoluteFilePath();
+
+    m_presetHasChanged = false;
+    adaptWindowTitle();
+}
+
+void PresetManager::savePresetsAs()
+{
+   QString name = QFileDialog::getSaveFileName(qobject_cast<QWidget*>(parent()), "Save Presets As", QGC::appDataDirectory(),
+                                               "Analyzing Presets (*.ini);;All Files (*.*)");
+
+   if(!name.isEmpty())
+   {
+       int pointIndex = name.lastIndexOf('.');  // lastIndexOf '.' shall find the . right before the extension
+       if(pointIndex > 0)
+       {
+           name.truncate(pointIndex);   // If found just remove the old extension completely
+       }
+       name.append(".ini");     // now add the new ".ini" extension
+
+       m_presetFile.setFile(name);
+       savePresets();
+   }
+}
+
+void PresetManager::removePresets()
+{
+    if(m_currentPreset.mp_menuAction != 0)
+    {
+        mp_menu->removeAction(m_currentPreset.mp_menuAction);
+        m_NameToPresetMap.remove(m_currentPreset.m_presetName);
+    }
+    QLOG_DEBUG() << "PresetManager::removePresets() - removed preset:" << m_currentPreset.m_presetName;
+    m_currentPreset = presetData();
+    m_presetHasChanged = true;
+}

--- a/src/ui/Loghandling/PresetManager.h
+++ b/src/ui/Loghandling/PresetManager.h
@@ -1,0 +1,222 @@
+/*===================================================================
+APM_PLANNER Open Source Ground Control Station
+
+(c) 2017 APM_PLANNER PROJECT <http://www.ardupilot.com>
+
+This file is part of the APM_PLANNER project
+
+    APM_PLANNER is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    APM_PLANNER is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with APM_PLANNER. If not, see <http://www.gnu.org/licenses/>.
+
+======================================================================*/
+/**
+ * @file PresetManager.h
+ * @author Arne Wischmann <wischmann-a@gmx.de>
+ * @date 13 Apr 2017
+ * @brief File providing header for the Preset manager class
+ */
+
+#ifndef PRESETMANAGER_H
+#define PRESETMANAGER_H
+
+#include <QObject>
+#include <QMenu>
+#include <QColor>
+
+#include "qcustomplot.h"
+
+
+/**
+ * @brief The PresetManager class provides a menu for the menubar which
+ *        brings some preset handling. Presets are preconfigured graph
+ *        settings used in Log analysis. This manager provides all services
+ *        neede to handle the presets. The menu itself and it entries are
+ *        managed by ths class too. It supports file persistence for the
+ *        presets.
+ */
+class PresetManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    /**
+     * @brief The presetElement struct - holds all data needed to reconstruct one special Graph
+     */
+    struct presetElement
+    {
+        QString   m_graph;          /// Name of the graph
+        QColor    m_color;          /// Color of the graph
+        QCPRange  m_range;          /// y-axis range of the graph
+        QString   m_group;          /// Group name if grouped, empty when not grouped
+        bool      m_manualRange;    /// Flag for manual scaling - if true y-axis range will be used - false graph will be autoscaled
+
+        presetElement() : m_manualRange(false) {}
+    };
+
+    typedef QVector<presetElement> presetElementVec;    /// type holding several preset elements thus defining a preset.
+
+    /**
+     * @brief PresetManager - CTOR
+     * @param p_parent - Pointer to parent widget
+     * @param p_menuBar - Pointer to menu bar of the parent widget
+     */
+    explicit PresetManager(QWidget *p_parent, QMenuBar *p_menuBar);
+
+    /**
+     * @brief ~PresetManager - DTOR
+     */
+    virtual ~PresetManager();
+
+    /**
+     * @brief getFileInfo - To get the QFileInfo of the loaded preset
+     *        used for persistence.
+     * @return - the QFileInfo of the loaded preset.
+     */
+    QFileInfo getFileInfo() const;
+
+    /**
+     * @brief setFileName - Sets the filename of the preset to load.
+     *        if the file is found and valid the presets will be loaded.
+     * @param fileName - Name of the preset file to be loaded
+     */
+    void setFileName(const QString &fileName);
+
+    /**
+     * @brief getSelectedPreset - Delivers the currently selected preset.
+     * @return - The selected preset
+     */
+    presetElementVec getSelectedPreset() const;
+
+    /**
+     * @brief saveSpecialSet - saves the delivered preset directly to the APM Planner
+     *        ini file. By doing this the preset is accessible from all log analysis
+     *        windows.
+     * @param preset - the preset data to store
+     * @param usesTimeAxis - Is the time on X-Axis enabled?
+     */
+    void saveSpecialSet(const presetElementVec &preset, bool usesTimeAxis) const;
+
+    /**
+     * @brief loadSpecialSet - loads a preset directly from the APM Planner ini file.
+     * @param preset - the loaded preset data.
+     * @return - true if time on X-Axis was used.
+     */
+    bool loadSpecialSet(presetElementVec &preset) const;
+
+    /**
+     * @brief addToCurrentPresets - adds the preset to the preset menu and stores
+     *        it in the internal map. User will be prompted for a preset name.
+     * @param preset - preset data to be added.
+     */
+    void addToCurrentPresets(const presetElementVec &preset);
+
+signals:
+
+    /**
+     * @brief newPresetSelected - This signal is emitted whenever the preset changes.
+     */
+    void newPresetSelected(PresetManager::presetElementVec);
+
+private:
+
+    /**
+     * @brief The presetData struct - is an internal used struct to enrich the presetElementVec
+     *        with some additional information for internal handling
+     */
+    struct presetData
+    {
+        QString m_presetName;               /// Name of the preset itself
+        QAction *mp_menuAction;             /// Pointer to menubar entry
+        presetElementVec m_enabledGraphs;   /// the corresponding preset element vector
+
+        presetData() : mp_menuAction(0) {}
+    };
+
+    QMenu *mp_menu;                 /// Pointer to our menu in menubar
+    QFileInfo m_presetFile;         /// file info of loaded *.ini file
+    QMap<QString, presetData> m_NameToPresetMap;    /// Map holding preset name and its settings
+    presetData m_currentPreset;     /// The current selected preset
+
+    bool m_presetHasChanged;        /// Always true if the loaded preset has changed
+
+    /**
+     * @brief readPresetFile - starts to load a preset file. Mainly it loads the version information
+     *        of the preset file and selects the appropriate loading method.
+     */
+    void readPresetFile();
+
+    /**
+     * @brief readPresetFileVersion10 - is used to load preset files of version 1.0
+     * @param presets - The preset to load the data from.
+     */
+    void readPresetFileVersion10(QSettings &presets);
+
+    /**
+     * @brief checkAndSaveIfPresetModified - tests the m_presetHasChanged flag and if its set
+     *        it prompts the user to save the changed set.
+     */
+    void checkAndSaveIfPresetModified();
+
+    /**
+     * @brief adoptWindowTitle - adopts the window title to the loaded preset. Window title shall look like
+     *        "Graph: 'filename of loaded log' ['filename of the loaded preset']"
+     */
+    void adaptWindowTitle() const;
+
+private slots:
+
+    /**
+     * @brief loadPresets - starts preset loading - triggered by menu bar entry
+     */
+    void loadPresets();
+
+    /**
+     * @brief loadDialogAccepted - callback for loadPresets(). Gets the selected filename and loads
+     *        the preset
+     */
+    void loadDialogAccepted();
+
+    /**
+     * @brief handlePresetSelected - is called as soon as one preset is selected from menu.
+     *        Gets the name of the selected preset and enables it.
+     */
+    void handlePresetSelected();
+
+    /**
+     * @brief removeAllPresets - removes all presets from the menubar
+     */
+    void removeAllPresets();
+
+    /**
+     * @brief savePresetCheckingFilename - saves the current presets. If filename is empty
+     *        user will be promted to enter one.
+     */
+    void savePresetCheckingFilename();
+
+    /**
+     * @brief savePresets - saves the current presets. Does not check whether the filename is empty.
+     */
+    void savePresets();
+
+    /**
+     * @brief savePresetsAs - saves preset in another file. User will be prompted for new filename.
+     */
+    void savePresetsAs();
+
+    /**
+     * @brief removePresets - removes the curently selected Preset from the menubar
+     */
+    void removePresets();
+};
+
+#endif // PRESETMANAGER_H

--- a/src/ui/map/QGCMapWidget.cc
+++ b/src/ui/map/QGCMapWidget.cc
@@ -31,6 +31,7 @@ QGCMapWidget::QGCMapWidget(QWidget *parent) :
     connect(currWPManager, SIGNAL(waypointEditableChanged(int, Waypoint*)), this, SLOT(updateWaypoint(int,Waypoint*)));
     connect(this, SIGNAL(waypointCreated(Waypoint*)), currWPManager, SLOT(addWaypointEditable(Waypoint*)));
     connect(this, SIGNAL(waypointChanged(Waypoint*)), currWPManager, SLOT(notifyOfChangeEditable(Waypoint*)));
+    connect(map, SIGNAL(mapChanged()), this, SLOT(redrawWaypointLines()));
     offlineMode = true;
     // Widget is inactive until shown
     defaultGuidedRelativeAlt = 100.0; // Default set to 100m
@@ -393,7 +394,6 @@ void QGCMapWidget::activeUASSet(UASInterface* uas)
         disconnect(currWPManager, SIGNAL(waypointEditableChanged(int, Waypoint*)), this, SLOT(updateWaypoint(int,Waypoint*)));
         disconnect(this, SIGNAL(waypointCreated(Waypoint*)), currWPManager, SLOT(addWaypointEditable(Waypoint*)));
         disconnect(this, SIGNAL(waypointChanged(Waypoint*)), currWPManager, SLOT(notifyOfChangeEditable(Waypoint*)));
-        disconnect(map, SIGNAL(mapChanged()), this, SLOT(redrawWaypointLines()));
 
         QGraphicsItemGroup* group = waypointLine(this->uas ? this->uas->getUASID() : 0);
         if (group)
@@ -420,7 +420,7 @@ void QGCMapWidget::activeUASSet(UASInterface* uas)
     connect(currWPManager, SIGNAL(waypointEditableChanged(int, Waypoint*)), this, SLOT(updateWaypoint(int,Waypoint*)));
     connect(this, SIGNAL(waypointCreated(Waypoint*)), currWPManager, SLOT(addWaypointEditable(Waypoint*)));
     connect(this, SIGNAL(waypointChanged(Waypoint*)), currWPManager, SLOT(notifyOfChangeEditable(Waypoint*)));
-    connect(map, SIGNAL(mapChanged()), this, SLOT(redrawWaypointLines()));
+
 }
 
 /**


### PR DESCRIPTION
Hi all,
this is the PR for the new Loganalysis preset feature. As discussed in #1026 this brings individual configurable graphing presets for speeding up log analysis and view sharing between different analysis windows for easier comparison of log data.
Moreover there is a bugfix for waypoint lines not moving when panning the map, and an enhancement / fix for the KML export which should now export the plane model with correct yaw, roll and pitch. Also the CDATA in the export was fixed.
