### PR TITLE
WIP: add feature: plane timestamps

### DIFF
--- a/src/output/kmlcreator.h
+++ b/src/output/kmlcreator.h
@@ -24,9 +24,13 @@ struct GPSRecord: DataLine {
     QString lng()   { return values.value("Lng"); }
     QString alt()   { return values.value("Alt"); }
     QString speed() { return values.value("Spd"); }
+    QString week()  { return values.value("GWk"); }
+    QString msec()  { return values.value("GMS"); }
 
     virtual bool hasData() {
-        return (values.value("Lat").length() > 0);
+        bool status;
+        int week = values.value("GWk").toInt(&status);
+        return status && (week > 0);
     }
 
     QString toStringForKml() {

--- a/src/output/kmlcreator.h
+++ b/src/output/kmlcreator.h
@@ -172,6 +172,8 @@ private:
     QList<CommandedWaypoint> m_waypoints;
     QHash<QString, FormatLine> m_formatLines;
     SummaryData* m_summary;
+
+    bool m_newGPSMessage;
 };
 
 } // namespace kml

--- a/src/ui/map/QGCMapWidget.cc
+++ b/src/ui/map/QGCMapWidget.cc
@@ -31,6 +31,7 @@ QGCMapWidget::QGCMapWidget(QWidget *parent) :
     connect(currWPManager, SIGNAL(waypointEditableChanged(int, Waypoint*)), this, SLOT(updateWaypoint(int,Waypoint*)));
     connect(this, SIGNAL(waypointCreated(Waypoint*)), currWPManager, SLOT(addWaypointEditable(Waypoint*)));
     connect(this, SIGNAL(waypointChanged(Waypoint*)), currWPManager, SLOT(notifyOfChangeEditable(Waypoint*)));
+    connect(map, SIGNAL(mapChanged()), this, SLOT(redrawWaypointLines()));
     offlineMode = true;
     // Widget is inactive until shown
     defaultGuidedRelativeAlt = 100.0; // Default set to 100m
@@ -393,7 +394,6 @@ void QGCMapWidget::activeUASSet(UASInterface* uas)
         disconnect(currWPManager, SIGNAL(waypointEditableChanged(int, Waypoint*)), this, SLOT(updateWaypoint(int,Waypoint*)));
         disconnect(this, SIGNAL(waypointCreated(Waypoint*)), currWPManager, SLOT(addWaypointEditable(Waypoint*)));
         disconnect(this, SIGNAL(waypointChanged(Waypoint*)), currWPManager, SLOT(notifyOfChangeEditable(Waypoint*)));
-        disconnect(map, SIGNAL(mapChanged()), this, SLOT(redrawWaypointLines()));
 
         QGraphicsItemGroup* group = waypointLine(this->uas ? this->uas->getUASID() : 0);
         if (group)
@@ -420,7 +420,7 @@ void QGCMapWidget::activeUASSet(UASInterface* uas)
     connect(currWPManager, SIGNAL(waypointEditableChanged(int, Waypoint*)), this, SLOT(updateWaypoint(int,Waypoint*)));
     connect(this, SIGNAL(waypointCreated(Waypoint*)), currWPManager, SLOT(addWaypointEditable(Waypoint*)));
     connect(this, SIGNAL(waypointChanged(Waypoint*)), currWPManager, SLOT(notifyOfChangeEditable(Waypoint*)));
-    connect(map, SIGNAL(mapChanged()), this, SLOT(redrawWaypointLines()));
+
 }
 
 /**


### PR DESCRIPTION
@Arne-W This is a small mod to your bugfix branch to add GPS time to plane placemarks.
I had to robustify the GPS record validation check because I was getting records with zero week and week_msec fields, and that screws up Google Earth.
If it's working correctly, you should get a "time slider" at the upper left of the GE map display as soon as you load a KMZ file.

This could easily be added to the flight path data also.