### PR TITLE
Some small fixes in opmapcontrol

### DIFF
--- a/libs/opmapcontrol/src/common.pri
+++ b/libs/opmapcontrol/src/common.pri
@@ -7,4 +7,3 @@ TEMPLATE = lib
 UI_DIR = uics
 MOC_DIR = mocs
 OBJECTS_DIR = objs
-INCLUDEPATH +=../../../../libs/

--- a/libs/opmapcontrol/src/core/cache.cpp
+++ b/libs/opmapcontrol/src/core/cache.cpp
@@ -25,7 +25,6 @@
 * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 #include "cache.h"
-#include "utils/pathutils.h"
 #include <QSettings>
 
 namespace core {

--- a/libs/opmapcontrol/src/internals/core.cpp
+++ b/libs/opmapcontrol/src/internals/core.cpp
@@ -67,8 +67,8 @@ namespace internals {
     {
         ProcessLoadTaskCallback.waitForDone();
         Matrix.Clear();
-        if (projection)
-            delete projection;
+        delete projection;
+        projection = 0;
     }
 
     void Core::run()

--- a/libs/opmapcontrol/src/internals/core.cpp
+++ b/libs/opmapcontrol/src/internals/core.cpp
@@ -42,6 +42,7 @@ namespace internals {
     minOfTiles(0,0),
     maxOfTiles(0,0),
     zoom(0),
+    projection(nullptr),
     isDragging(false),
     TooltipTextPadding(10,10),
     mapType(static_cast<MapType::Types>(0)),
@@ -65,6 +66,9 @@ namespace internals {
     Core::~Core()
     {
         ProcessLoadTaskCallback.waitForDone();
+        Matrix.Clear();
+        if (projection)
+            delete projection;
     }
 
     void Core::run()

--- a/libs/opmapcontrol/src/internals/core.cpp
+++ b/libs/opmapcontrol/src/internals/core.cpp
@@ -42,7 +42,7 @@ namespace internals {
     minOfTiles(0,0),
     maxOfTiles(0,0),
     zoom(0),
-    projection(nullptr),
+    projection(0),
     isDragging(false),
     TooltipTextPadding(10,10),
     mapType(static_cast<MapType::Types>(0)),

--- a/libs/opmapcontrol/src/internals/core.h
+++ b/libs/opmapcontrol/src/internals/core.h
@@ -135,9 +135,7 @@ namespace internals {
         }
         void SetProjection(PureProjection* value)
         {
-            if (projection)
-                delete projection;
-
+            delete projection;
             projection=value;
             tileRect=Rectangle(core::Point(0,0),value->TileSize());
         }

--- a/libs/opmapcontrol/src/internals/core.h
+++ b/libs/opmapcontrol/src/internals/core.h
@@ -135,6 +135,9 @@ namespace internals {
         }
         void SetProjection(PureProjection* value)
         {
+            if (projection)
+                delete projection;
+
             projection=value;
             tileRect=Rectangle(core::Point(0,0),value->TileSize());
         }

--- a/libs/opmapcontrol/src/internals/pureprojection.h
+++ b/libs/opmapcontrol/src/internals/pureprojection.h
@@ -44,6 +44,8 @@ class PureProjection
 
 
 public:
+    virtual ~PureProjection() {}
+
     virtual Size TileSize()const=0;
 
     virtual double Axis()const=0;

--- a/libs/opmapcontrol/src/mapwidget/mapwidget.pro
+++ b/libs/opmapcontrol/src/mapwidget/mapwidget.pro
@@ -1,9 +1,13 @@
 TEMPLATE = lib
 TARGET = opmapwidget
 DEFINES += OPMAPWIDGET_LIBRARY
-include(../../../../openpilotgcslibrary.pri)
 
-# DESTDIR = ../build
+OBJECTS_DIR = objs
+DESTDIR = ../build
+
+#QMAKE_CXXFLAGS += -fsanitize=address -fno-omit-frame-pointer
+#QMAKE_LFLAGS += -fsanitize=address -fno-omit-frame-pointer
+
 SOURCES += mapgraphicitem.cpp \
     opmapwidget.cpp \
     configuration.cpp \
@@ -22,14 +26,12 @@ LIBS += -L../build \
     -lcore
 
 # order of linking matters
-include(../../../utils/utils.pri)
 
 POST_TARGETDEPS  += ../build/libcore.a
 POST_TARGETDEPS  += ../build/libinternals.a
 
 HEADERS += mapgraphicitem.h \
     opmapwidget.h \
-    configuration.h \
     waypointitem.h \
     uavitem.h \
     gpsitem.h \
@@ -39,7 +41,8 @@ HEADERS += mapgraphicitem.h \
     homeitem.h \
     mapripform.h \
     mapripper.h \
-    traillineitem.h
+    traillineitem.h \
+    omapconfiguration.h
 QT += opengl
 QT += network
 QT += sql

--- a/libs/opmapcontrol/src/mapwidget/mapwidget.pro
+++ b/libs/opmapcontrol/src/mapwidget/mapwidget.pro
@@ -3,11 +3,7 @@ TARGET = opmapwidget
 DEFINES += OPMAPWIDGET_LIBRARY
 
 OBJECTS_DIR = objs
-DESTDIR = ../build
-
-#QMAKE_CXXFLAGS += -fsanitize=address -fno-omit-frame-pointer
-#QMAKE_LFLAGS += -fsanitize=address -fno-omit-frame-pointer
-
+#DESTDIR = ../build
 SOURCES += mapgraphicitem.cpp \
     opmapwidget.cpp \
     configuration.cpp \

--- a/libs/opmapcontrol/src/mapwidget/waypointitem.cpp
+++ b/libs/opmapcontrol/src/mapwidget/waypointitem.cpp
@@ -26,7 +26,6 @@
 */
 #include "waypointitem.h"
 #include <QGraphicsSceneMouseEvent>
-#include <logging.h>
 namespace mapcontrol
 {
     WayPointItem::WayPointItem(const internals::PointLatLng &coord,double const& altitude, MapGraphicItem *map) :


### PR DESCRIPTION
While using the opmapcontrol lib in another project I came across some issues like memory leaks and deprecated project files. The committed changes fix those.