### PR TITLE
Flightplan: Introduced GraphicsItem base class for graphics items on map

### DIFF
--- a/apm_planner.pro
+++ b/apm_planner.pro
@@ -165,6 +165,7 @@ DEFINES += _TTY_NOWARN_
 
 RaspberryPiBuild {
    DEFINES -= CAMERAVIEW
+   CONFIG += c++11 #C++11 support
 }
 
 MacBuild {
@@ -189,6 +190,8 @@ MacBuild {
 }
 
 LinuxBuild {
+
+    CONFIG += c++11 #C++11 support
     DEFINES += __STDC_LIMIT_MACROS
 
     DEFINES += GIT_COMMIT=$$system(git describe --dirty=-DEV --always)
@@ -201,6 +204,8 @@ LinuxBuild {
 }
 
 WindowsBuild {
+
+    CONFIG += c++11 #C++11 support
     DEFINES += __STDC_LIMIT_MACROS
 
     # Specify multi-process compilation within Visual Studio.
@@ -218,6 +223,8 @@ WindowsBuild {
 }
 
 WindowsCrossBuild {
+
+    CONFIG += c++11 #C++11 support
     QT += script
     # Windows version cross compiled on linux using
     DEFINES += __STDC_LIMIT_MACROS

--- a/libs/opmapcontrol/opmapcontrol_external.pri
+++ b/libs/opmapcontrol/opmapcontrol_external.pri
@@ -61,7 +61,9 @@ HEADERS += libs/opmapcontrol/opmapcontrol.h \
            libs/opmapcontrol/src/internals/projections/platecarreeprojection.h \
            libs/opmapcontrol/src/internals/projections/platecarreeprojectionpergo.h \
            libs/opmapcontrol/src/mapwidget/waypointlineitem.h \
-    libs/opmapcontrol/src/mapwidget/omapconfiguration.h
+           libs/opmapcontrol/src/mapwidget/omapconfiguration.h \
+           libs/opmapcontrol/src/mapwidget/graphicsitem.h \
+           libs/opmapcontrol/src/mapwidget/graphicsusertypes.h
 FORMS += libs/opmapcontrol/src/mapwidget/mapripform.ui
 SOURCES += libs/opmapcontrol/src/core/alllayersoftype.cpp \
            libs/opmapcontrol/src/core/cache.cpp \

--- a/libs/opmapcontrol/src/mapwidget/gpsitem.cpp
+++ b/libs/opmapcontrol/src/mapwidget/gpsitem.cpp
@@ -26,15 +26,21 @@
 */
 #include "../internals/pureprojection.h"
 #include "gpsitem.h"
+#include "mapgraphicitem.h"
+#include "opmapwidget.h"
+#include "trailitem.h"
+#include "traillineitem.h"
 namespace mapcontrol
 {
-    GPSItem::GPSItem(MapGraphicItem* map,OPMapWidget* parent,QString uavPic):map(map),mapwidget(parent),showtrail(true),showtrailline(true),trailtime(5),traildistance(50),autosetreached(true)
-    ,autosetdistance(100)
+    GPSItem::GPSItem(MapGraphicItem* map,OPMapWidget* parent,QString uavPic) :
+        GraphicsItem(map, parent),
+        showtrail(true), showtrailline(true), trailtime(5), traildistance(50),
+        autosetreached(true), autosetdistance(100)
     {
-        pic.load(uavPic);
+        picture.load(uavPic);
        // Don't scale but trust the image we are given
        // pic=pic.scaled(50,33,Qt::IgnoreAspectRatio);
-        localposition=map->FromLatLngToLocal(mapwidget->CurrentPosition());
+        core::Point localposition = map->FromLatLngToLocal(mapwidget->CurrentPosition());
         this->setPos(localposition.X(),localposition.Y());
         this->setZValue(4);
         trail=new QGraphicsItemGroup();
@@ -56,12 +62,12 @@ namespace mapcontrol
         Q_UNUSED(option);
         Q_UNUSED(widget);
        // painter->rotate(-90);
-        painter->drawPixmap(-pic.width()/2,-pic.height()/2,pic);
-       //   painter->drawRect(QRectF(-pic.width()/2,-pic.height()/2,pic.width()-1,pic.height()-1));
+        painter->drawPixmap(-picture.width()/2,-picture.height()/2,picture);
+       //   painter->drawRect(QRectF(-picture.width()/2,-picture.height()/2,picture.width()-1,picture.height()-1));
     }
     QRectF GPSItem::boundingRect()const
     {
-        return QRectF(-pic.width()/2,-pic.height()/2,pic.width(),pic.height());
+        return QRectF(-picture.width()/2,-picture.height()/2,picture.width(),picture.height());
     }
     void GPSItem::SetUAVPos(const internals::PointLatLng &position, const int &altitude)
     {
@@ -167,7 +173,7 @@ namespace mapcontrol
 
     void GPSItem::RefreshPos()
     {
-        localposition=map->FromLatLngToLocal(coord);
+        core::Point localposition = map->FromLatLngToLocal(coord);
         this->setPos(localposition.X(),localposition.Y());
         foreach(QGraphicsItem* i,trail->childItems())
         {
@@ -215,6 +221,6 @@ namespace mapcontrol
     }
     void GPSItem::SetUavPic(QString UAVPic)
     {
-        pic.load(":/uavs/images/"+UAVPic);
+        picture.load(":/uavs/images/"+UAVPic);
     }
 }

--- a/libs/opmapcontrol/src/mapwidget/gpsitem.h
+++ b/libs/opmapcontrol/src/mapwidget/gpsitem.h
@@ -27,35 +27,27 @@
 #ifndef GPSITEM_H
 #define GPSITEM_H
 
-#include <QGraphicsItem>
-#include <QPainter>
-#include <QLabel>
-#include "../internals/pointlatlng.h"
-#include "mapgraphicitem.h"
-#include "waypointitem.h"
-#include <QObject>
+#include <QTime>
+#include "graphicsitem.h"
+#include "graphicsusertypes.h"
 #include "uavmapfollowtype.h"
 #include "uavtrailtype.h"
-#include <QtSvg/QSvgRenderer>
-#include "opmapwidget.h"
-#include "trailitem.h"
-#include "traillineitem.h"
+
 namespace mapcontrol
 {
     class WayPointItem;
-    class OPMapWidget;
     /**
 * @brief A QGraphicsItem representing the UAV
 *
 * @class UAVItem gpsitem.h "mapwidget/gpsitem.h"
 */
-    class GPSItem:public QObject,public QGraphicsItem
+    class GPSItem : public GraphicsItem
     {
         Q_OBJECT
         Q_INTERFACES(QGraphicsItem)
     public:
-                enum { Type = UserType + 6 };
-        GPSItem(MapGraphicItem* map,OPMapWidget* parent, QString uavPic=QString::fromUtf8(":/uavs/images/mapquad.png"));
+        enum { Type = usertypes::GPSITEM };
+        GPSItem(MapGraphicItem* map, OPMapWidget* parent, QString uavPic=QString::fromUtf8(":/uavs/images/mapquad.png"));
         ~GPSItem();
         /**
         * @brief Sets the UAV position
@@ -194,16 +186,10 @@ namespace mapcontrol
 
         void SetUavPic(QString UAVPic);
     private:
-        MapGraphicItem* map;
-
         int altitude;
         UAVMapFollowType::Types mapfollowtype;
         UAVTrailType::Types trailtype;
-        internals::PointLatLng coord;
         internals::PointLatLng lastcoord;
-        QPixmap pic;
-        core::Point localposition;
-        OPMapWidget* mapwidget;
         QGraphicsItemGroup* trail;
         QGraphicsItemGroup * trailLine;
         internals::PointLatLng lasttrailline;

--- a/libs/opmapcontrol/src/mapwidget/graphicsitem.h
+++ b/libs/opmapcontrol/src/mapwidget/graphicsitem.h
@@ -1,9 +1,9 @@
 /**
 ******************************************************************************
 *
-* @file       traillineitem.h
-* @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
-* @brief      A graphicsItem representing a WayPoint
+* @file       graphicsitem.h
+* @author     Dino Hüllmann
+* @brief      Base class for graphics items
 * @see        The GNU Public License (GPL) Version 3
 * @defgroup   OPMapWidget
 * @{
@@ -24,40 +24,41 @@
 * with this program; if not, write to the Free Software Foundation, Inc.,
 * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
-#ifndef TAILLINEITEM_H
-#define TAILLINEITEM_H
+#ifndef GRAPHICSITEM_H
+#define GRAPHICSITEM_H
 
-#include <QGraphicsItem>
-#include <QPainter>
-#include <QLabel>
-#include "../internals/pointlatlng.h"
 #include <QObject>
-#include "graphicsusertypes.h"
+#include <QGraphicsItem>
+#include "../internals/pointlatlng.h"
 
 namespace mapcontrol
 {
+    class MapGraphicItem;
+    class OPMapWidget;
 
-    class TrailLineItem:public QObject,public QGraphicsLineItem
+    /**
+     * @brief Base class for graphics items shown on the map
+     *
+     * @class GraphicsItem graphicsitem.h "graphicsitem.h"
+     */
+    class GraphicsItem : public QObject, public QGraphicsItem
     {
         Q_OBJECT
         Q_INTERFACES(QGraphicsItem)
     public:
-                enum { Type = usertypes::TRAILLINEITEM };
-        TrailLineItem(internals::PointLatLng const& coord1,internals::PointLatLng const& coord2, QBrush color, QGraphicsItem* parent);
-        int type() const;
-      //  void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
-       //             QWidget *widget);
-        internals::PointLatLng coord1;
-        internals::PointLatLng coord2;
-    private:
-        QBrush m_brush;
+        GraphicsItem(MapGraphicItem* map, OPMapWidget* parent)
+            : map(map), mapwidget(parent)
+        {}
 
+        virtual ~GraphicsItem() {}
 
-    public slots:
-
-    signals:
-
+        virtual void RefreshPos() = 0;
+    protected:
+        MapGraphicItem* map;
+        OPMapWidget* mapwidget;
+        QPixmap picture;
+        internals::PointLatLng coord;
     };
-}
+} // namespace mapcontrol
 
-#endif // TAILLINEITEM_H
+#endif // GRAPHICSITEM_H

--- a/libs/opmapcontrol/src/mapwidget/graphicsusertypes.h
+++ b/libs/opmapcontrol/src/mapwidget/graphicsusertypes.h
@@ -1,9 +1,9 @@
 /**
 ******************************************************************************
 *
-* @file       traillineitem.h
-* @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
-* @brief      A graphicsItem representing a WayPoint
+* @file       graphicsusertypes.h
+* @author     Dino Hüllmann
+* @brief      User type definitions for QGraphicsItems
 * @see        The GNU Public License (GPL) Version 3
 * @defgroup   OPMapWidget
 * @{
@@ -24,40 +24,23 @@
 * with this program; if not, write to the Free Software Foundation, Inc.,
 * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
-#ifndef TAILLINEITEM_H
-#define TAILLINEITEM_H
+#ifndef GRAPHICSUSERTYPES_H
+#define GRAPHICSUSERTYPES_H
 
 #include <QGraphicsItem>
-#include <QPainter>
-#include <QLabel>
-#include "../internals/pointlatlng.h"
-#include <QObject>
-#include "graphicsusertypes.h"
 
 namespace mapcontrol
 {
-
-    class TrailLineItem:public QObject,public QGraphicsLineItem
+    namespace usertypes
     {
-        Q_OBJECT
-        Q_INTERFACES(QGraphicsItem)
-    public:
-                enum { Type = usertypes::TRAILLINEITEM };
-        TrailLineItem(internals::PointLatLng const& coord1,internals::PointLatLng const& coord2, QBrush color, QGraphicsItem* parent);
-        int type() const;
-      //  void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
-       //             QWidget *widget);
-        internals::PointLatLng coord1;
-        internals::PointLatLng coord2;
-    private:
-        QBrush m_brush;
+        constexpr int WAYPOINTITEM     = QGraphicsItem::UserType + 1;
+        constexpr int UAVITEM          = QGraphicsItem::UserType + 2;
+        constexpr int TRAILITEM        = QGraphicsItem::UserType + 3;
+        constexpr int HOMEITEM         = QGraphicsItem::UserType + 4;
+        constexpr int GPSITEM          = QGraphicsItem::UserType + 5;
+        constexpr int WAYPOINTLINEITEM = QGraphicsItem::UserType + 6;
+        constexpr int TRAILLINEITEM    = QGraphicsItem::UserType + 7;
+    } // namespace usertypes
+} // namespace mapcontrol
 
-
-    public slots:
-
-    signals:
-
-    };
-}
-
-#endif // TAILLINEITEM_H
+#endif // GRAPHICSUSERTYPES_H

--- a/libs/opmapcontrol/src/mapwidget/homeitem.cpp
+++ b/libs/opmapcontrol/src/mapwidget/homeitem.cpp
@@ -25,14 +25,19 @@
 * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 #include "homeitem.h"
+#include "mapgraphicitem.h"
+#include "opmapwidget.h"
 namespace mapcontrol
 {
-    HomeItem::HomeItem(MapGraphicItem* map,OPMapWidget* parent):safe(true),map(map),mapwidget(parent),showsafearea(true),safearea(1000),altitude(0)
+    HomeItem::HomeItem(MapGraphicItem* map,OPMapWidget* parent) :
+        GraphicsItem(map, parent),
+        safe(true), showsafearea(true), safearea(1000),
+        altitude(0)
     {
-        pic.load(QString::fromUtf8(":/markers/images/home2.svg"));
-        pic=pic.scaled(30,30,Qt::IgnoreAspectRatio);
+        picture.load(QString::fromUtf8(":/markers/images/home2.svg"));
+        picture=picture.scaled(30,30,Qt::IgnoreAspectRatio);
         this->setFlag(QGraphicsItem::ItemIgnoresTransformations,true);
-        localposition=map->FromLatLngToLocal(mapwidget->CurrentPosition());
+        core::Point localposition = map->FromLatLngToLocal(mapwidget->CurrentPosition());
         this->setPos(localposition.X(),localposition.Y());
         this->setZValue(4);
         coord=internals::PointLatLng(50,50);
@@ -46,7 +51,7 @@ namespace mapcontrol
     {
         Q_UNUSED(option);
         Q_UNUSED(widget);
-        painter->drawPixmap(-pic.width()/2,-pic.height()/2,pic);
+        painter->drawPixmap(-picture.width()/2,-picture.height()/2,picture);
         if(showsafearea)
         {
             if(safe)
@@ -61,7 +66,7 @@ namespace mapcontrol
     QRectF HomeItem::boundingRect()const
     {
         if(!showsafearea)
-            return QRectF(-pic.width()/2,-pic.height()/2,pic.width(),pic.height());
+            return QRectF(-picture.width()/2,-picture.height()/2,picture.width(),picture.height());
         else
             return QRectF(-localsafearea,-localsafearea,localsafearea*2,localsafearea*2);
     }
@@ -74,7 +79,7 @@ namespace mapcontrol
     void HomeItem::RefreshPos()
     {
         prepareGeometryChange();
-        localposition=map->FromLatLngToLocal(coord);
+        core::Point localposition = map->FromLatLngToLocal(coord);
         this->setPos(localposition.X(),localposition.Y());
         if(showsafearea)
             localsafearea=safearea/map->Projection()->GetGroundResolution(map->ZoomTotal(),coord.Lat());

--- a/libs/opmapcontrol/src/mapwidget/homeitem.h
+++ b/libs/opmapcontrol/src/mapwidget/homeitem.h
@@ -27,22 +27,18 @@
 #ifndef HOMEITEM_H
 #define HOMEITEM_H
 
-#include <QGraphicsItem>
-#include <QPainter>
-#include <QLabel>
-#include "../internals/pointlatlng.h"
-#include <QObject>
-#include "opmapwidget.h"
+#include "graphicsitem.h"
+#include "graphicsusertypes.h"
+
 namespace mapcontrol
 {
-
-    class HomeItem:public QObject,public QGraphicsItem
+    class HomeItem : public GraphicsItem
     {
         Q_OBJECT
         Q_INTERFACES(QGraphicsItem)
     public:
-                enum { Type = UserType + 4 };
-        HomeItem(MapGraphicItem* map,OPMapWidget* parent);
+        enum { Type = usertypes::HOMEITEM };
+        HomeItem(MapGraphicItem* map, OPMapWidget* parent);
         void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
                     QWidget *widget);
         QRectF boundingRect() const;
@@ -58,11 +54,6 @@ namespace mapcontrol
         void SetAltitude(int const& value){altitude=value;}
         int Altitude()const{return altitude;}
     private:
-        MapGraphicItem* map;
-        OPMapWidget* mapwidget;
-        QPixmap pic;
-        core::Point localposition;
-        internals::PointLatLng coord;
         bool showsafearea;
         int safearea;
         int localsafearea;

--- a/libs/opmapcontrol/src/mapwidget/mapgraphicitem.cpp
+++ b/libs/opmapcontrol/src/mapwidget/mapgraphicitem.cpp
@@ -24,11 +24,9 @@
 * with this program; if not, write to the Free Software Foundation, Inc.,
 * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
-#include "uavitem.h"
-#include "gpsitem.h"
-#include "homeitem.h"
+#include "graphicsitem.h"
 #include "mapgraphicitem.h"
-#include "waypointlineitem.h"
+#include <QGraphicsScene>
 #include <QGraphicsSceneMouseEvent>
 
 namespace mapcontrol
@@ -87,40 +85,14 @@ namespace mapcontrol
     void MapGraphicItem::Core_OnNeedInvalidation()
     {
         this->update();
-        foreach(QGraphicsItem* i,this->childItems())
-        {
-            WayPointItem* w=qgraphicsitem_cast<WayPointItem*>(i);
-            if(w)
-                w->RefreshPos();
-            UAVItem* ww=qgraphicsitem_cast<UAVItem*>(i);
-            if(ww)
-                ww->RefreshPos();
-            HomeItem* www=qgraphicsitem_cast<HomeItem*>(i);
-            if(www)
-                www->RefreshPos();
-            GPSItem* wwww=qgraphicsitem_cast<GPSItem*>(i);
-            if(wwww)
-                wwww->RefreshPos();
-
-            emit mapChanged();
-        }
+        ChildPosRefresh();
     }
     void MapGraphicItem::ChildPosRefresh()
     {
         foreach(QGraphicsItem* i,this->childItems())
         {
-            WayPointItem* w=qgraphicsitem_cast<WayPointItem*>(i);
-            if(w)
+            if (GraphicsItem* w = dynamic_cast<GraphicsItem*>(i))
                 w->RefreshPos();
-            UAVItem* ww=qgraphicsitem_cast<UAVItem*>(i);
-            if(ww)
-                ww->RefreshPos();
-            HomeItem* www=qgraphicsitem_cast<HomeItem*>(i);
-            if(www)
-                www->RefreshPos();
-            GPSItem* wwww=qgraphicsitem_cast<GPSItem*>(i);
-            if(wwww)
-                wwww->RefreshPos();
 
             emit mapChanged();
         }

--- a/libs/opmapcontrol/src/mapwidget/mapgraphicitem.h
+++ b/libs/opmapcontrol/src/mapwidget/mapgraphicitem.h
@@ -38,8 +38,7 @@
 #include <QBrush>
 #include <QFont>
 #include <QObject>
-#include "waypointitem.h"
-//#include "uavitem.h"
+
 namespace mapcontrol
 {
     class OPMapWidget;

--- a/libs/opmapcontrol/src/mapwidget/mapwidget.pro
+++ b/libs/opmapcontrol/src/mapwidget/mapwidget.pro
@@ -38,7 +38,9 @@ HEADERS += mapgraphicitem.h \
     mapripform.h \
     mapripper.h \
     traillineitem.h \
-    omapconfiguration.h
+    omapconfiguration.h \
+    graphicsitem.h \
+    graphicsusertypes.h
 QT += opengl
 QT += network
 QT += sql

--- a/libs/opmapcontrol/src/mapwidget/opmapwidget.cpp
+++ b/libs/opmapcontrol/src/mapwidget/opmapwidget.cpp
@@ -276,7 +276,7 @@ namespace mapcontrol
     ////////////////WAYPOINT////////////////////////
     WayPointItem* OPMapWidget::WPCreate()
     {
-        WayPointItem* item=new WayPointItem(this->CurrentPosition(),0,map);
+        WayPointItem* item = new WayPointItem(this->CurrentPosition(), 0, map, this);
         ConnectWP(item);
         item->setParentItem(map);
         return item;
@@ -317,21 +317,21 @@ namespace mapcontrol
     }
     WayPointItem* OPMapWidget::WPCreate(internals::PointLatLng const& coord,int const& altitude)
     {
-        WayPointItem* item=new WayPointItem(coord,altitude,map);
+        WayPointItem* item = new WayPointItem(coord, altitude, map, this);
         ConnectWP(item);
         item->setParentItem(map);
         return item;
     }
     WayPointItem* OPMapWidget::WPCreate(internals::PointLatLng const& coord,int const& altitude, QString const& description)
     {
-        WayPointItem* item=new WayPointItem(coord,altitude,description,map);
+        WayPointItem* item = new WayPointItem(coord, altitude, map, this, description);
         ConnectWP(item);
         item->setParentItem(map);
         return item;
     }
     WayPointItem* OPMapWidget::WPInsert(const int &position)
     {
-        WayPointItem* item=new WayPointItem(this->CurrentPosition(),0,map);
+        WayPointItem* item = new WayPointItem(this->CurrentPosition(), 0, map, this);
         item->SetNumber(position);
         ConnectWP(item);
         item->setParentItem(map);
@@ -348,7 +348,7 @@ namespace mapcontrol
     }
     WayPointItem* OPMapWidget::WPInsert(internals::PointLatLng const& coord,int const& altitude,const int &position)
     {
-        WayPointItem* item=new WayPointItem(coord,altitude,map);
+        WayPointItem* item = new WayPointItem(coord, altitude, map, this);
         item->SetNumber(position);
         ConnectWP(item);
         item->setParentItem(map);
@@ -357,7 +357,7 @@ namespace mapcontrol
     }
     WayPointItem* OPMapWidget::WPInsert(internals::PointLatLng const& coord,int const& altitude, QString const& description,const int &position)
     {
-        WayPointItem* item=new WayPointItem(coord,altitude,description,map);
+        WayPointItem* item = new WayPointItem(coord, altitude, map, this, description);
         item->SetNumber(position);
         ConnectWP(item);
         item->setParentItem(map);

--- a/libs/opmapcontrol/src/mapwidget/trailitem.h
+++ b/libs/opmapcontrol/src/mapwidget/trailitem.h
@@ -32,6 +32,7 @@
 #include <QLabel>
 #include "../internals/pointlatlng.h"
 #include <QObject>
+#include "graphicsusertypes.h"
 
 namespace mapcontrol
 {
@@ -41,7 +42,7 @@ namespace mapcontrol
         Q_OBJECT
         Q_INTERFACES(QGraphicsItem)
     public:
-                enum { Type = UserType + 3 };
+                enum { Type = usertypes::TRAILITEM };
         TrailItem(internals::PointLatLng const& coord,int const& altitude, QBrush color, QGraphicsItem* parent);
         void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
                     QWidget *widget);

--- a/libs/opmapcontrol/src/mapwidget/uavitem.cpp
+++ b/libs/opmapcontrol/src/mapwidget/uavitem.cpp
@@ -26,17 +26,25 @@
 */
 #include "../internals/pureprojection.h"
 #include "uavitem.h"
+#include "mapgraphicitem.h"
+#include "opmapwidget.h"
+#include "trailitem.h"
+#include "traillineitem.h"
 namespace mapcontrol
 {
-    UAVItem::UAVItem(MapGraphicItem* map,OPMapWidget* parent,QString uavPic):map(map),mapwidget(parent),showtrail(true),showtrailline(true),trailtime(5),traildistance(20),autosetreached(true)
-    ,autosetdistance(100)
+    //UAVItem::UAVItem(MapGraphicItem* map,OPMapWidget* parent,QString uavPic):map(map),mapwidget(parent),showtrail(true),showtrailline(true),trailtime(5),traildistance(20),autosetreached(true)
+    //,autosetdistance(100)
+    UAVItem::UAVItem(MapGraphicItem* map,OPMapWidget* parent,QString uavPic) :
+        GraphicsItem(map, parent),
+        showtrail(true), showtrailline(true), trailtime(5), traildistance(20),
+        autosetreached(true), autosetdistance(100)
     {
         //QDir dir(":/uavs/images/");
         //QStringList list=dir.entryList();
-        pic.load(uavPic);
+        picture.load(uavPic);
        // Don't scale but trust the image we are given
-       // pic=pic.scaled(50,33,Qt::IgnoreAspectRatio);
-        localposition=map->FromLatLngToLocal(mapwidget->CurrentPosition());
+       // picture=picture.scaled(50,33,Qt::IgnoreAspectRatio);
+        core::Point localposition = map->FromLatLngToLocal(mapwidget->CurrentPosition());
         this->setPos(localposition.X(),localposition.Y());
         this->setZValue(4);
         trail=new QGraphicsItemGroup();
@@ -60,13 +68,13 @@ namespace mapcontrol
        // painter->rotate(-90);
         QPainter::RenderHints oldhints = painter->renderHints();
         painter->setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
-        painter->drawPixmap(-pic.width()/2,-pic.height()/2,pic);
+        painter->drawPixmap(-picture.width()/2,-picture.height()/2,picture);
         painter->setRenderHints(oldhints);
-       //   painter->drawRect(QRectF(-pic.width()/2,-pic.height()/2,pic.width()-1,pic.height()-1));
+       //   painter->drawRect(QRectF(-picture.width()/2,-picture.height()/2,picture.width()-1,picture.height()-1));
     }
     QRectF UAVItem::boundingRect()const
     {
-        return QRectF(-pic.width()/2,-pic.height()/2,pic.width(),pic.height());
+        return QRectF(-picture.width()/2,-picture.height()/2,picture.width(),picture.height());
     }
     void UAVItem::SetUAVPos(const internals::PointLatLng &position, const int &altitude, const QColor &color)
     {
@@ -171,7 +179,7 @@ namespace mapcontrol
 
     void UAVItem::RefreshPos()
     {
-        localposition=map->FromLatLngToLocal(coord);
+        core::Point localposition = map->FromLatLngToLocal(coord);
         this->setPos(localposition.X(),localposition.Y());
         foreach(QGraphicsItem* i,trail->childItems())
         {
@@ -218,6 +226,6 @@ namespace mapcontrol
     }
     void UAVItem::SetUavPic(QString UAVPic)
     {
-        pic.load(":/uavs/images/"+UAVPic);
+        picture.load(":/uavs/images/"+UAVPic);
     }
 }

--- a/libs/opmapcontrol/src/mapwidget/uavitem.h
+++ b/libs/opmapcontrol/src/mapwidget/uavitem.h
@@ -27,35 +27,27 @@
 #ifndef UAVITEM_H
 #define UAVITEM_H
 
-#include <QGraphicsItem>
-#include <QPainter>
-#include <QLabel>
-#include "../internals/pointlatlng.h"
-#include "mapgraphicitem.h"
-#include "waypointitem.h"
-#include <QObject>
+#include <QTime>
+#include "graphicsitem.h"
+#include "graphicsusertypes.h"
 #include "uavmapfollowtype.h"
 #include "uavtrailtype.h"
-#include <QtSvg/QSvgRenderer>
-#include "opmapwidget.h"
-#include "trailitem.h"
-#include "traillineitem.h"
+
 namespace mapcontrol
 {
     class WayPointItem;
-    class OPMapWidget;
     /**
 * @brief A QGraphicsItem representing the UAV
 *
 * @class UAVItem uavitem.h "mapwidget/uavitem.h"
 */
-    class UAVItem:public QObject,public QGraphicsItem
+    class UAVItem : public GraphicsItem
     {
         Q_OBJECT
         Q_INTERFACES(QGraphicsItem)
     public:
-                enum { Type = UserType + 2 };
-        UAVItem(MapGraphicItem* map,OPMapWidget* parent, QString uavPic=QString::fromUtf8(":/uavs/images/mapquad.png"));
+        enum { Type = usertypes::UAVITEM };
+        UAVItem(MapGraphicItem* map, OPMapWidget* parent, QString uavPic=QString::fromUtf8(":/uavs/images/mapquad.png"));
         ~UAVItem();
         /**
         * @brief Sets the UAV position
@@ -194,19 +186,11 @@ namespace mapcontrol
 
         void SetUavPic(QString UAVPic);
 
-    protected:
-        QPixmap pic;
-
     private:
-        MapGraphicItem* map;
-
         int altitude;
         UAVMapFollowType::Types mapfollowtype;
         UAVTrailType::Types trailtype;
-        internals::PointLatLng coord;
         internals::PointLatLng lastcoord;
-        core::Point localposition;
-        OPMapWidget* mapwidget;
         QGraphicsItemGroup* trail;
         QGraphicsItemGroup * trailLine;
         internals::PointLatLng lasttrailline;

--- a/libs/opmapcontrol/src/mapwidget/waypointitem.cpp
+++ b/libs/opmapcontrol/src/mapwidget/waypointitem.cpp
@@ -26,23 +26,26 @@
 */
 #include "waypointitem.h"
 #include <QGraphicsSceneMouseEvent>
+#include <QPainter>
+#include "mapgraphicitem.h"
+#include "../internals/pointlatlng.h"
 namespace mapcontrol
 {
-    WayPointItem::WayPointItem(const internals::PointLatLng &coord,double const& altitude, MapGraphicItem *map) :
-        map(map),
+    WayPointItem::WayPointItem(const internals::PointLatLng &wp_coord, double const& altitude, MapGraphicItem *map, OPMapWidget *parent, const QString &description) :
+        GraphicsItem(map, parent),
         autoreachedEnabled(true),
         text(NULL),
         textBG(NULL),
         numberI(NULL),
         numberIBG(NULL),
-        coord(coord),
         reached(false),
-        description(""),
+        description(description),
         shownumber(true),
         altitude(altitude), // sets a 10m default just in case
         heading(0),
         number(0)
     {
+        coord = wp_coord;
         picture.load(QString::fromUtf8(":/markers/images/marker.png"));
         number=WayPointItem::snumber++;
         setFlag(QGraphicsItem::ItemIsMovable,true);
@@ -53,57 +56,28 @@ namespace mapcontrol
         RefreshPos();
         setAcceptedMouseButtons(Qt::LeftButton);
 
-        text   = new QGraphicsSimpleTextItem(this);
-        text->setPen(QPen(Qt::red));
-        text->setPos(10,-picture.height());
-        text->setZValue(3);
-        text->setVisible(false);
-
-        textBG = new QGraphicsRectItem(this);
-        textBG->setBrush(QColor(255, 255, 255, 128));
-        textBG->setOpacity(0.5);
-        textBG->setPos(10,-picture.height());
-        textBG->setVisible(false);
-    }
-
-    WayPointItem::WayPointItem(const internals::PointLatLng &coord,double const& altitude, const QString &description, MapGraphicItem *map) :
-        map(map),
-        autoreachedEnabled(true),
-        text(NULL),
-        textBG(NULL),
-        numberI(NULL),
-        numberIBG(NULL),
-        coord(coord),
-        reached(false),
-        description(description),
-        shownumber(true),
-        altitude(altitude), // sets a 10m default just in case
-        heading(0),
-        number(0)
-    {
-        picture.load(QString::fromUtf8(":/markers/images/marker.png"));
-        number=WayPointItem::snumber++;
-        setFlag(QGraphicsItem::ItemIsMovable,true);
-        setFlag(QGraphicsItem::ItemIgnoresTransformations,true);
-        setFlag(QGraphicsItem::ItemIsSelectable,true);
-        SetShowNumber(shownumber);
-        RefreshToolTip();
-        RefreshPos();
-        setAcceptedMouseButtons(Qt::AllButtons);
-
-        // TODO have fun with colors....
         text = new QGraphicsSimpleTextItem(this);
-//        text->setPen(QPen(Qt::red));
-        text->setBrush(QBrush(Qt::red));
         text->setPos(10,-picture.height());
         text->setZValue(3);
         text->setVisible(false);
 
         textBG = new QGraphicsRectItem(this);
-        textBG->setBrush(QColor(255, 255, 255, 200));
-        textBG->setOpacity(0.8);
         textBG->setPos(10,-picture.height());
         textBG->setVisible(false);
+
+        if (description.isEmpty())
+        {
+            text->setPen(QPen(Qt::red));
+            textBG->setBrush(QColor(255, 255, 255, 128));
+            textBG->setOpacity(0.5);
+        }
+        else
+        {
+            text->setBrush(QBrush(Qt::red));
+
+            textBG->setBrush(QColor(255, 255, 255, 200));
+            textBG->setOpacity(0.8);
+        }
     }
 
     WayPointItem::~WayPointItem()

--- a/libs/opmapcontrol/src/mapwidget/waypointitem.h
+++ b/libs/opmapcontrol/src/mapwidget/waypointitem.h
@@ -27,12 +27,9 @@
 #ifndef WAYPOINTITEM_H
 #define WAYPOINTITEM_H
 
-#include <QGraphicsItem>
-#include <QPainter>
-#include <QLabel>
-#include "../internals/pointlatlng.h"
-#include "mapgraphicitem.h"
-#include <QObject>
+#include "graphicsitem.h"
+#include "graphicsusertypes.h"
+
 namespace mapcontrol
 {
 /**
@@ -40,34 +37,25 @@ namespace mapcontrol
 *
 * @class WayPointItem waypointitem.h "waypointitem.h"
 */
-class WayPointItem: public QObject, public QGraphicsItem
+class WayPointItem : public GraphicsItem
 {
     Q_OBJECT
     Q_INTERFACES(QGraphicsItem)
 public:
-    enum { Type = UserType + 1 };
+    enum { Type = usertypes::WAYPOINTITEM };
     /**
     * @brief Constructer
     *
     * @param coord coordinates in LatLng of the Waypoint
     * @param altitude altitude of the WayPoint
     * @param map pointer to map to use
+    * @param parent pointer to parent widget
+    * @param description description for the WayPoint
     * @return 
     */
-    WayPointItem(internals::PointLatLng const& coord,double const& altitude,MapGraphicItem* map);
-    /**
-    * @brief Constructer
-    *
-    * @param coord coordinates in LatLng of the WayPoint
-    * @param altitude altitude of the WayPoint
-    * @param description description fo the WayPoint
-    * @param map pointer to map to use
-    * @return
-    */
-    WayPointItem(internals::PointLatLng const& coord,double const& altitude,QString const& description,MapGraphicItem* map);
+    WayPointItem(internals::PointLatLng const& wp_coord, double const& altitude, MapGraphicItem* map, OPMapWidget* parent, QString const& description = "");
 
     virtual ~WayPointItem();
-
 
     /**
     * @brief Returns the WayPoint description
@@ -157,8 +145,6 @@ public:
                 QWidget *widget);
     void RefreshPos();
     void RefreshToolTip();
-    QPixmap picture;
-
 
     static int snumber;
 protected:
@@ -166,14 +152,12 @@ protected:
     void mousePressEvent ( QGraphicsSceneMouseEvent * event );
     void mouseReleaseEvent ( QGraphicsSceneMouseEvent * event );
 
-    MapGraphicItem* map;
     bool autoreachedEnabled;    ///< If the waypoint should change appearance once it has been reached
     QGraphicsSimpleTextItem* text;
     QGraphicsRectItem* textBG;
     QGraphicsSimpleTextItem* numberI;
     QGraphicsRectItem* numberIBG;
     QTransform transf;
-    internals::PointLatLng coord;//coordinates of this WayPoint
     bool reached;
     QString description;
     bool shownumber;

--- a/libs/opmapcontrol/src/mapwidget/waypointlineitem.h
+++ b/libs/opmapcontrol/src/mapwidget/waypointlineitem.h
@@ -3,6 +3,7 @@
 
 #include <QGraphicsLineItem>
 #include "../../opmapcontrol.h"
+#include "graphicsusertypes.h"
 
 namespace mapcontrol {
 class WaypointLineItem : public QObject,public QGraphicsLineItem
@@ -10,7 +11,7 @@ class WaypointLineItem : public QObject,public QGraphicsLineItem
     Q_OBJECT
     Q_INTERFACES(QGraphicsItem)
 public:
-    enum { Type = UserType + 7 };
+    enum { Type = usertypes::WAYPOINTLINEITEM };
     WaypointLineItem(WayPointItem* wp1, WayPointItem* wp2, QColor color=QColor(Qt::red), MapGraphicItem* parent=0);
     int type() const;
 

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -149,7 +149,7 @@ void LinkManager::loadSettings()
                 settings.setArrayIndex(j);
                 QString host = settings.value("host").toString();
                 int port = settings.value("port").toInt();
-                iface->addHost(tr("%1:%2").arg(host, port));
+                iface->addHost(tr("%1:%2").arg(host).arg(port));
             }
             settings.endArray(); // HOSTS
         }

--- a/src/ui/Loghandling/BinLogParser.h
+++ b/src/ui/Loghandling/BinLogParser.h
@@ -64,10 +64,10 @@ public:
 
 private:
 
-    static const quint8 s_FMTMessageType = 0x80; /// Type Id of the format (FMT) message
+    static const quint8 s_FMTMessageType  = 0x80; /// Type Id of the format (FMT) message
     static const quint8 s_STRTMessageType = 0x0A; /// Type Id of the Start (STRT) message
 
-    static const int s_MinHeaderSize  = 5;       /// Minimal size to be able to start parsing
+    static const int s_MinHeaderSize = 5;        /// Minimal size to be able to start parsing
     static const int s_HeaderOffset  = 3;        /// byte offset after successful header parsing
     static const quint8 s_StartByte1 = 0xA3;     /// Startbyte 1 is always first byte in one message
     static const quint8 s_StartByte2 = 0x95;     /// Startbyte 2 is always second byte in one message
@@ -75,6 +75,9 @@ private:
     static const int s_FMTNameSize   = 4;        /// Size of the name field in FMT message
     static const int s_FMTFormatSize = 16;       /// Size of the format field in FMT message
     static const int s_FMTLabelsSize = 64;       /// Size of the comma delimited names field in FMT message
+
+    static const quint32 s_FloatSoftNaN  = 0x7FC04152;         /// Value to detect a quiet/soft float NaN from ardupilot
+    static const quint64 s_DoubleSoftNaN = 0x7FF952445550490A; /// Value to detect a quiet/soft double NaN from ardupilot
 
 
     /**

--- a/src/ui/Loghandling/LogAnalysis.cpp
+++ b/src/ui/Loghandling/LogAnalysis.cpp
@@ -712,9 +712,9 @@ void LogAnalysis::logLoadingDone(AP2DataPlotStatus status)
     QLOG_DEBUG() << "LogAnalysis::logLoadingDone - Log loading is done.";
     m_loadedLogMavType = status.getMavType();
 
-    // close progress window
-    m_loadProgressDialog->close();
-    m_loadProgressDialog.reset();
+    // close progress window. When setting value of the progress window to 100 it will
+    // automatically close
+    m_loadProgressDialog->setValue(100);
 
     // status handling
     if (status.getParsingState() != AP2DataPlotStatus::OK)

--- a/src/ui/QGCParamWidget.cc
+++ b/src/ui/QGCParamWidget.cc
@@ -1008,6 +1008,7 @@ void QGCParamWidget::retransmissionGuardTick()
                 transmissionMissingWriteAckPackets.value(component)->clear();
             }
             statusLabel->setText(tr("TIMEOUT! MISSING: %1 read, %2 write.").arg(missingReadCount).arg(missingWriteCount));
+            QLOG_WARN() << tr("TIMEOUT! MISSING: %1 read, %2 write.").arg(missingReadCount).arg(missingWriteCount);
         }
 
         // Re-request at maximum retransmissionBurstRequestSize parameters at once
@@ -1025,6 +1026,7 @@ void QGCParamWidget::retransmissionGuardTick()
                         //QLOG_DEBUG() << __FILE__ << __LINE__ << "RETRANSMISSION GUARD REQUESTS RETRANSMISSION OF PARAM #" << id << "FROM COMPONENT #" << component;
                         emit requestParameter(component, id);
                         statusLabel->setText(tr("Requested retransmission of #%1").arg(id+1));
+                        QLOG_INFO() <<tr("Requested retransmission of #%1").arg(id+1);
                         count++;
                     } else {
                         break;
@@ -1101,11 +1103,15 @@ void QGCParamWidget::setParameter(int component, QString parameterName, QVariant
     if (paramMin.contains(parameterName) && value.toDouble() < paramMin.value(parameterName))
     {
         statusLabel->setText(tr("REJ. %1 < min").arg(value.toDouble()));
+        QLOG_INFO() << "setParameter: Value for" << parameterName << "is too small." << value.toDouble()
+                    << "<" << paramMin.value(parameterName);
         return;
     }
     if (paramMax.contains(parameterName) && value.toDouble() > paramMax.value(parameterName))
     {
         statusLabel->setText(tr("REJ. %1 > max").arg(value.toDouble()));
+        QLOG_INFO() << "setParameter: Value for" << parameterName << "is too big." << value.toDouble()
+                    << ">" << paramMax.value(parameterName);
         return;
     }
 
@@ -1119,6 +1125,8 @@ void QGCParamWidget::setParameter(int component, QString parameterName, QVariant
     if (parameterList->value(parameterName) == value)
     {
         statusLabel->setText(tr("REJ. %1 > max").arg(value.toDouble()));
+        QLOG_INFO() << "setParameter: Value for" << parameterName << "did not change." << value.toDouble()
+                    << "=" << parameterList->value(parameterName);
         return;
     }
 

--- a/src/ui/map/MAV2DIcon.cc
+++ b/src/ui/map/MAV2DIcon.cc
@@ -16,7 +16,7 @@ MAV2DIcon::MAV2DIcon(mapcontrol::MapGraphicItem* map,mapcontrol::OPMapWidget* pa
     uasid(uas->getUASID())
 {
     size = QSize(radius, radius);
-    pic = QPixmap(size);
+    picture = QPixmap(size);
     drawIcon();
 }
 
@@ -30,7 +30,7 @@ MAV2DIcon::MAV2DIcon(mapcontrol::MapGraphicItem* map, mapcontrol::OPMapWidget* p
     uasid(0)
 {
     size = QSize(radius, radius);
-    pic = QPixmap(size);
+    picture = QPixmap(size);
     drawIcon();
     SetUAVPos(internals::PointLatLng(lat, lon), alt, color);
 }
@@ -66,13 +66,13 @@ void MAV2DIcon::setYaw(float yaw)
 
 void MAV2DIcon::drawIcon()
 {
-    pic.fill(Qt::transparent);
-    QPainter painter(&pic);
+    picture.fill(Qt::transparent);
+    QPainter painter(&picture);
     painter.setRenderHint(QPainter::TextAntialiasing);
     painter.setRenderHint(QPainter::Antialiasing);
     painter.setRenderHint(QPainter::HighQualityAntialiasing);
 
-    radius = qMin(pic.width(), pic.height());
+    radius = qMin(picture.width(), picture.height());
 
     // Rotate by yaw
     painter.translate(radius/2, radius/2);

--- a/src/ui/map/Waypoint2DIcon.cc
+++ b/src/ui/map/Waypoint2DIcon.cc
@@ -5,7 +5,7 @@
 #include <QPainter>
 
 Waypoint2DIcon::Waypoint2DIcon(mapcontrol::MapGraphicItem* map, mapcontrol::OPMapWidget* parent, qreal latitude, qreal longitude, qreal altitude, int listindex, QString name, QString description, int radius)
-    : mapcontrol::WayPointItem(internals::PointLatLng(latitude, longitude), altitude, description, map),
+    : mapcontrol::WayPointItem(internals::PointLatLng(latitude, longitude), altitude, map, parent, description),
     parent(parent),
     waypoint(NULL),
     radius(radius),
@@ -26,7 +26,7 @@ Waypoint2DIcon::Waypoint2DIcon(mapcontrol::MapGraphicItem* map, mapcontrol::OPMa
 }
 
 Waypoint2DIcon::Waypoint2DIcon(mapcontrol::MapGraphicItem* map, mapcontrol::OPMapWidget* parent, Waypoint* wp, const QColor& color, int listindex, int radius)
-    : mapcontrol::WayPointItem(internals::PointLatLng(wp->getLatitude(), wp->getLongitude()), wp->getAltitude(), wp->getDescription(), map),
+    : mapcontrol::WayPointItem(internals::PointLatLng(wp->getLatitude(), wp->getLongitude()), wp->getAltitude(), map, parent, wp->getDescription()),
     parent(parent),
     waypoint(wp),
     radius(radius),

--- a/src/ui/uas/UASActionsWidget.cpp
+++ b/src/ui/uas/UASActionsWidget.cpp
@@ -354,38 +354,19 @@ void UASActionsWidget::changeSpeedClicked()
 
     QLOG_INFO() << "Change Vehicle Speed ";
 
-    if (m_uas->isMultirotor())
-    {
-        QLOG_INFO() << "APMCopter: setting WPNAV_SPEED: " << ui.speedDoubleSpinBox->value() * 100.0f;
-        m_uas->setParameter(1,"WPNAV_SPEED",
-                            QVariant((static_cast<float>(ui.speedDoubleSpinBox->value() * 100.0f))));
-        return;
-    }
-    else if (m_uas->isFixedWing())
-    {
-        // [TODO} need to add AirSpeed/GroundSpeed options here as well
-        QVariant variant;
-        if (m_uas->getParamManager()->getParameterValue(1,"ARSPD_ENABLE",variant))
-        {
-            if (variant.toInt() == 1)
-            {
-                QLOG_INFO() << "APMPlane: ARSPD_ENABLED setting TRIM_ARSPD_CN";
-                m_uas->setParameter(1,"TRIM_ARSPD_CN",
-                                    QVariant((static_cast<float>(ui.speedDoubleSpinBox->value() * 100.0f))));
-                return;
-            }
+	int confirm = 1;    // Confirm.
+	float param1 = 0.0; // Empty
+	float param2 = ui.speedDoubleSpinBox->value();
+	float param3 = 0.0; //
+	float param4 = 0.0; //
+	float param5 = 0.0; // Latitude
+	float param6 = 0.0; // Longitude
+	float param7 = 0.0; // Altitude
+	int component = MAV_COMP_ID_PRIMARY;
+	m_uas->executeCommand(MAV_CMD_DO_CHANGE_SPEED,
+						  confirm, param1, param2, param3,
+						  param4, param5, param6, param7, component);
 
-        }
-        QLOG_INFO() << "APMPlane: setting TRIM_ARSPD_CN";
-        m_uas->setParameter(1,"TRIM_ARSPD_CN",
-                            QVariant((static_cast<float>(ui.speedDoubleSpinBox->value() * 100.0f))));
-
-    } else if (m_uas->isGroundRover()) {
-        QLOG_INFO() << "APMCopter: setting CRUISE_SPEED: " << ui.speedDoubleSpinBox->value() * 100.0f;
-        m_uas->setParameter(1, "CRUISE_SPEED",
-                            QVariant((static_cast<float>(ui.speedDoubleSpinBox->value() * 100.0f))));
-
-    }
 }
 
 void UASActionsWidget::setMode()


### PR DESCRIPTION
Follow-up pull request to PR #1083 .

The commit introduces a new GraphicsItem base class for 1st-level child graphics items shown on the map (currently: GPSItem, HomeItem, UAVItem, WaypointItem). This approach allows an easy extension of the items and avoids duplicated code.

I struggled a bit with [mapgraphicitem.cpp:125](https://github.com/ArduPilot/apm_planner/pull/1085/files#diff-4ca69cb6bc9197e2f5d3734df23ca9acL125): Does it make sense to emit the mapChanged() signal after each item having updated its position or would it be sufficient to emit this signal once after all positions are updated?