### PR TITLE
NaN handling and small fixes

### DIFF
--- a/src/ui/Loghandling/BinLogParser.h
+++ b/src/ui/Loghandling/BinLogParser.h
@@ -64,10 +64,10 @@ public:
 
 private:
 
-    static const quint8 s_FMTMessageType = 0x80; /// Type Id of the format (FMT) message
+    static const quint8 s_FMTMessageType  = 0x80; /// Type Id of the format (FMT) message
     static const quint8 s_STRTMessageType = 0x0A; /// Type Id of the Start (STRT) message
 
-    static const int s_MinHeaderSize  = 5;       /// Minimal size to be able to start parsing
+    static const int s_MinHeaderSize = 5;        /// Minimal size to be able to start parsing
     static const int s_HeaderOffset  = 3;        /// byte offset after successful header parsing
     static const quint8 s_StartByte1 = 0xA3;     /// Startbyte 1 is always first byte in one message
     static const quint8 s_StartByte2 = 0x95;     /// Startbyte 2 is always second byte in one message
@@ -75,6 +75,9 @@ private:
     static const int s_FMTNameSize   = 4;        /// Size of the name field in FMT message
     static const int s_FMTFormatSize = 16;       /// Size of the format field in FMT message
     static const int s_FMTLabelsSize = 64;       /// Size of the comma delimited names field in FMT message
+
+    static const quint32 s_FloatSoftNaN  = 0x7FC04152;         /// Value to detect a quiet/soft float NaN from ardupilot
+    static const quint64 s_DoubleSoftNaN = 0x7FF952445550490A; /// Value to detect a quiet/soft double NaN from ardupilot
 
 
     /**

--- a/src/ui/Loghandling/LogAnalysis.cpp
+++ b/src/ui/Loghandling/LogAnalysis.cpp
@@ -712,9 +712,9 @@ void LogAnalysis::logLoadingDone(AP2DataPlotStatus status)
     QLOG_DEBUG() << "LogAnalysis::logLoadingDone - Log loading is done.";
     m_loadedLogMavType = status.getMavType();
 
-    // close progress window
-    m_loadProgressDialog->close();
-    m_loadProgressDialog.reset();
+    // close progress window. When setting value of the progress window to 100 it will
+    // automatically close
+    m_loadProgressDialog->setValue(100);
 
     // status handling
     if (status.getParsingState() != AP2DataPlotStatus::OK)

--- a/src/ui/QGCParamWidget.cc
+++ b/src/ui/QGCParamWidget.cc
@@ -1008,6 +1008,7 @@ void QGCParamWidget::retransmissionGuardTick()
                 transmissionMissingWriteAckPackets.value(component)->clear();
             }
             statusLabel->setText(tr("TIMEOUT! MISSING: %1 read, %2 write.").arg(missingReadCount).arg(missingWriteCount));
+            QLOG_WARN() << tr("TIMEOUT! MISSING: %1 read, %2 write.").arg(missingReadCount).arg(missingWriteCount);
         }
 
         // Re-request at maximum retransmissionBurstRequestSize parameters at once
@@ -1025,6 +1026,7 @@ void QGCParamWidget::retransmissionGuardTick()
                         //QLOG_DEBUG() << __FILE__ << __LINE__ << "RETRANSMISSION GUARD REQUESTS RETRANSMISSION OF PARAM #" << id << "FROM COMPONENT #" << component;
                         emit requestParameter(component, id);
                         statusLabel->setText(tr("Requested retransmission of #%1").arg(id+1));
+                        QLOG_INFO() <<tr("Requested retransmission of #%1").arg(id+1);
                         count++;
                     } else {
                         break;
@@ -1101,11 +1103,15 @@ void QGCParamWidget::setParameter(int component, QString parameterName, QVariant
     if (paramMin.contains(parameterName) && value.toDouble() < paramMin.value(parameterName))
     {
         statusLabel->setText(tr("REJ. %1 < min").arg(value.toDouble()));
+        QLOG_INFO() << "setParameter: Value for" << parameterName << "is too small." << value.toDouble()
+                    << "<" << paramMin.value(parameterName);
         return;
     }
     if (paramMax.contains(parameterName) && value.toDouble() > paramMax.value(parameterName))
     {
         statusLabel->setText(tr("REJ. %1 > max").arg(value.toDouble()));
+        QLOG_INFO() << "setParameter: Value for" << parameterName << "is too big." << value.toDouble()
+                    << ">" << paramMax.value(parameterName);
         return;
     }
 
@@ -1119,6 +1125,8 @@ void QGCParamWidget::setParameter(int component, QString parameterName, QVariant
     if (parameterList->value(parameterName) == value)
     {
         statusLabel->setText(tr("REJ. %1 > max").arg(value.toDouble()));
+        QLOG_INFO() << "setParameter: Value for" << parameterName << "did not change." << value.toDouble()
+                    << "=" << parameterList->value(parameterName);
         return;
     }
 


### PR DESCRIPTION
A new PR for handling the NaNs in flash (*.bin) logs. Besides that two minor fixes are introduced as well. One adds some output to the log file which were only shown in GUI, the other one fixes the one wrong log output which always marked a successful log loading as cancelled.