### PR TITLE
OpenBSD compatibility

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -13,6 +13,36 @@ LinuxBuild {
 	}
 }
 
+
+# BSD Build settings
+
+OpenBSDBuild {
+ INCLUDEPATH += \
+                /usr/local/include \
+                /usr/local/include/SDL2 \
+                /usr/X11R6/include \
+                /usr/X11R6/include
+
+	LIBS += \
+	        -L/usr/lib \
+          -lSDL2 \
+          -L/usr/local/lib \
+          -L/usr/X11R6/lib
+
+    exists(/usr/local/include/flite/flite.h) {
+        message(Adding Flite Support)
+        LIBS += \
+            -lflite_cmu_us_kal \
+            -lflite_usenglish \
+            -lflite_cmulex \
+            -lflite
+    } else {
+        message(Skipping Flite Support)
+        DEFINES -= FLITE_AUDIO_ENABLED
+    }
+
+}
+
 #
 # Add in a few missing headers to windows
 #

--- a/README.md
+++ b/README.md
@@ -128,6 +128,41 @@ sudo make install
 ```
 This will place the binary in your /bin/ folder and corresponding files in /share/
 
+
+OpenBSD
+========
+
+To build on OpenBSD 6.2
+-------------------
+1) install dependencies
+
+```
+pkg_add qt5 libsndfile sdl sdl2 flite py-serial py-pexpect openssl git
+```
+
+2) Clone the apm_planner repo
+
+```
+git clone git@github.com:ArduPilot/apm_planner.git
+```
+
+3) Build the project
+
+```
+cd apm_planner
+```
+
+```
+qmake-qt5 apm_planner.pro
+```
+
+```
+make
+```
+
+If the project compiled without errors you will find the binary in ./release
+
+
 Windows
 =======
 

--- a/apm_planner.pro
+++ b/apm_planner.pro
@@ -89,6 +89,13 @@ linux-g++-64 | linux-g++ {
 } else : macx-clang | macx-g++ {
     message(Mac build)
     CONFIG += MacBuild
+} else : openbsd-clang | openbsd-g++ {
+    message(OpenBSD build)
+
+    DEFINES += Q_OPENBSD
+
+    CONFIG += OpenBSDBuild
+
 } else {
     error(Unsupported build type)
 }
@@ -187,6 +194,22 @@ MacBuild {
 #    LIBS += -lssl -lcrypto
 #    LIBS +=
     LIBS += -framework ApplicationServices
+}
+
+
+OpenBSDBuild {
+
+    CONFIG += c++11 #C++11 support
+    DEFINES += __STDC_LIMIT_MACROS
+#    DEFINES += UDPLINK_DEBUG
+
+    DEFINES += GIT_COMMIT=$$system(git describe --dirty=-DEV --always)
+    DEFINES += GIT_HASH=$$system(git log -n 1 --pretty=format:%H)
+
+#    LIBS += -lsndfile
+    LIBS += -lz
+    LIBS += -lssl -lcrypto
+    DEFINES += OPENSSL
 }
 
 LinuxBuild {

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -40,7 +40,9 @@ MAVLinkProtocol::MAVLinkProtocol():
     m_isOnline(true),
     m_loggingEnabled(false),
     m_logfile(NULL),
-    m_connectionManager(NULL)
+    m_connectionManager(NULL),
+    m_enable_version_check(false)
+
 {
 }
 

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -47,6 +47,8 @@
 #define APP_PLATFORM fedora32
 #elif defined(Q_OS_LINUX)
 #define APP_PLATFORM debian32
+#elif defined(Q_OPENBSD)
+#define APP_PLATFORM OpenBSD
 #else
 #define APP_PLATFORM win
 #endif

--- a/src/ui/configuration/PX4FirmwareUploader.cc
+++ b/src/ui/configuration/PX4FirmwareUploader.cc
@@ -651,7 +651,9 @@ bool PX4FirmwareUploader::checkCOA(const QByteArray& serial, const QByteArray& s
         return false;
     }
 
-    int verify = RSA_verify(NID_sha1,(unsigned char*)serial.data(),serial.size(),(unsigned char*)signature.data(),signature.size(),EVP_PKEY_get0_RSA(pkey));
+    RSA *rsa_key = EVP_PKEY_get1_RSA(pkey);
+    int verify = RSA_verify(NID_sha1,(unsigned char*)serial.data(),serial.size(),(unsigned char*)signature.data(),signature.size(),rsa_key);
+    RSA_free(rsa_key);
     if (verify)
     {
         //Failed!


### PR DESCRIPTION
Update in readme on how to build apm_planner in OpenBSD 6.2

Solves issue #1095
Changed EVP_PKEY_get0 to get1 to make it usable with both libressl and openssl.
m_enable_version_check uninitialized evaluates true in OpenBSD.