### PR TITLE
WIP: modify KML exporter to facilitate analysis of aerobatic maneuvers

### DIFF
--- a/src/ui/Loghandling/LogAnalysis.cpp
+++ b/src/ui/Loghandling/LogAnalysis.cpp
@@ -1192,6 +1192,14 @@ void LogAnalysis::exportDialogAccepted()
     QString outputFileName = dialog->selectedFiles().at(0);
     dialog->close();
 
+    // force kml extension
+    int dotindex = outputFileName.indexOf(".");
+    if (dotindex < 0) {
+        outputFileName.append(".kml");
+    } else {
+        outputFileName = outputFileName.left(dotindex).append(".kml");
+    }
+
     if(m_kmlExport)
     {
         QLOG_DEBUG() << "iconInterval: " << m_iconInterval;

--- a/src/ui/Loghandling/LogExporter.cpp
+++ b/src/ui/Loghandling/LogExporter.cpp
@@ -189,7 +189,7 @@ void KmlLogExporter::writeLine(QString &line)
 void KmlLogExporter::endExport()
 {
     QString generated = m_kmlExporter.finish(true);
-    QString msg = QString("Successfull exported to %1.").arg(generated);
+    QString msg = QString("Successfully exported to %1.").arg(generated);
     QLOG_DEBUG() << msg;
     QMessageBox::information(0, "Export KML", msg);
 }


### PR DESCRIPTION
This PR automatically segments the flight path into "maneuvers" bounded by straight and level flight.
GE can animate this flightpath using a feature called "tours", and that might prove useful for log analysis.

Example KMZ file is here: https://drive.google.com/open?id=1DXqYigl2Eek_ZoIoXqK3eNfPJBOrbrEU

Download the file and open it in Google Earth, set the touring options as shown below:
![touring_options](https://user-images.githubusercontent.com/2300221/38175228-61e3a398-3596-11e8-8402-da2bcc87eb76.png)

then select the "tour" named maneuvers (leave the checkboxes as they were) and click the "play tour" button at the bottom of the "Places" sidebar:
![places_sidebar](https://user-images.githubusercontent.com/2300221/38175351-8a78b224-3598-11e8-8b07-9a99a5462260.png)

Also, clicking on the flightpath will pop up info including RPY angles, AOA, and speeds (exported at 5Hz):
![mdisplay](https://user-images.githubusercontent.com/2300221/38175461-f9714118-3599-11e8-8f0d-15bfcefba1df.png)
