### PR TITLE
Comms: linkmanager will only store one host IP for each UDP connection

### DIFF
--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -199,7 +199,8 @@ void LinkManager::saveSettings()
             UDPLink *link = qobject_cast<UDPLink*>(i.value());
             settings.setValue("type","UDP_LINK");
             settings.beginWriteArray("HOSTS");
-            for (int j=0;j<link->getHosts().size();j++)
+            // WARNING - HACK - we will only store the first HOST in list because the user cannot remove additional hosts
+            for (int j = 0; (j < link->getHosts().size()) && (j < 1); j++)
             {
                 settings.setArrayIndex(j);
                 settings.setValue("host",link->getHosts().at(j).toString());
@@ -359,7 +360,7 @@ void LinkManager::linkUpdated(LinkInterface *link)
 {
     emit linkChanged(link);
     emit linkChanged(link->getId());
-    saveSettings(); // [todo] may need to verify if this is needed always (refactor to link objects)
+//    saveSettings(); // TODO may need to verify if this is not needed
 }
 
 QString LinkManager::getLinkName(int linkid)


### PR DESCRIPTION
This is some sort of Hack. The Linkmanager and the UDPlink is able to handle more than on host IP making it possible to communicate with more than one UAVs simultaniously.
It seems that this feature leads to long startup times for some users see #1121.

I am not sure if this hack solves one issue by adding a new one for other users, as I do not use UDP links except for SITL!
Someone else should test and decide it this shall be merged!