### PR TITLE
Adding Unit support flashlog parser

### DIFF
--- a/src/ui/Loghandling/AsciiLogParser.cpp
+++ b/src/ui/Loghandling/AsciiLogParser.cpp
@@ -144,7 +144,7 @@ AP2DataPlotStatus AsciiLogParser::parse(QFile &logfile)
                 {
                     if(NameValuePairList.size() >= 1)   // need at least one element
                     {
-                        if(!storeNameValuePairList(NameValuePairList, descriptor))
+                        if(!extendedStoreNameValuePairList(NameValuePairList, descriptor))
                         {
                             return m_logLoadingState;
                         }
@@ -191,7 +191,20 @@ AP2DataPlotStatus AsciiLogParser::parse(QFile &logfile)
         m_logLoadingState.setNoMessageBytes(m_noMessageBytes);
     }
 
-    m_dataStoragePtr->setTimeStamp(m_activeTimestamp.m_name, m_activeTimestamp.m_divisor);
+    if(m_hasUnitData)
+    {
+       QStringList errors = m_dataStoragePtr->setupUnitData(m_activeTimestamp.m_name, m_activeTimestamp.m_divisor);
+       for(const auto &error : errors)
+       {
+           QLOG_WARN() << error;
+           m_logLoadingState.corruptFMTRead(static_cast<int>(m_MessageCounter), "Unit or scaling error. " + error);
+       }
+    }
+    else
+    {
+        m_dataStoragePtr->setTimeStamp(m_activeTimestamp.m_name, m_activeTimestamp.m_divisor);
+    }
+
     return m_logLoadingState;
 }
 
@@ -280,7 +293,7 @@ bool AsciiLogParser::parseDataByDescriptor(QList<NameValuePair> &NameValuePairLi
 {
     static QString intdef("bhi");   // unsigned 32 bit max types.
     static QString uintdef("BHI");  // signed 32 bit max types.
-    static QString floatdef("cCeEfL");
+    static QString floatdef("cCeEfLd");
     static QString chardef("nNZM");
 
     if(m_tokensToParse.size() != desc.m_format.size())

--- a/src/ui/Loghandling/AsciiLogParser.cpp
+++ b/src/ui/Loghandling/AsciiLogParser.cpp
@@ -333,7 +333,7 @@ bool AsciiLogParser::parseDataByDescriptor(QList<NameValuePair> &NameValuePairLi
         {
             bool ok = false;
             double value = token.toDouble(&ok);
-            if(ok && !qIsInf(value) && !qIsNaN(value))
+            if(ok && !qIsInf(value))
             {
                 NameValuePairList.append(NameValuePair(desc.getLabelAtIndex(i), value));
             }

--- a/src/ui/Loghandling/BinLogParser.h
+++ b/src/ui/Loghandling/BinLogParser.h
@@ -64,8 +64,11 @@ public:
 
 private:
 
-    static const quint32 s_FMTMessageType  = 0x80; /// Type Id of the format (FMT) message
-    static const quint32 s_STRTMessageType = 0x0A; /// Type Id of the Start (STRT) message
+    static const quint8 s_FMTMessageType  = 0x80; /// Type Id of the format (FMT) message
+    static const quint8 s_STRTMessageType = 0x0A; /// Type Id of the Start (STRT) message
+    static const quint8 s_UNITMessageType = 0xE5; /// Type Id of the unit (UNIT) message
+    static const quint8 s_MULTMessageType = 0xE6; /// Type Id of the multiplier (MULT) message
+    static const quint8 s_FMTUMessageType = 0xE4; /// Type Id of the Format unit multiplier (FMTU) message
 
     static const int s_MinHeaderSize = 5;        /// Minimal size to be able to start parsing
     static const int s_HeaderOffset  = 3;        /// byte offset after successful header parsing
@@ -97,6 +100,8 @@ private:
     QHash<quint32, binDescriptor> m_typeToDescriptorMap;   /// hashMap storing a format descriptor for every message type
 
     QList<binDescriptor> m_descriptorForDeferredStorage; /// temp list for storing descriptors without a timestamp field
+
+    bool m_hasUnitData;                     /// True if parsed log contains unit data
 
     /**
      * @brief headerIsValid checks the first 2 start bytes
@@ -139,6 +144,16 @@ private:
      * @return
      */
     bool parseDataByDescriptor(QList<NameValuePair> &NameValuePairList, const binDescriptor &desc);
+
+    /**
+     * @brief extendedStoreNameValuePairList checks for the unit data types (UNIT, MULT, FMTU)
+     *        and inserts them correctly into the datamodel. All other data will be passed to
+     *        the storeNameValuePairList() method of the base class
+     * @param NameValuePairList to be stored
+     * @param desc - matching descriptor for this NameValuePairList
+     * @return true success, false otherwise
+     */
+    bool extendedStoreNameValuePairList(QList<NameValuePair> &NameValuePairList, const typeDescriptor &desc);
 };
 
 #endif // BINLOGPARSER_H

--- a/src/ui/Loghandling/BinLogParser.h
+++ b/src/ui/Loghandling/BinLogParser.h
@@ -66,9 +66,7 @@ private:
 
     static const quint8 s_FMTMessageType  = 0x80; /// Type Id of the format (FMT) message
     static const quint8 s_STRTMessageType = 0x0A; /// Type Id of the Start (STRT) message
-    static const quint8 s_UNITMessageType = 0xE5; /// Type Id of the unit (UNIT) message
-    static const quint8 s_MULTMessageType = 0xE6; /// Type Id of the multiplier (MULT) message
-    static const quint8 s_FMTUMessageType = 0xE4; /// Type Id of the Format unit multiplier (FMTU) message
+
 
     static const int s_MinHeaderSize = 5;        /// Minimal size to be able to start parsing
     static const int s_HeaderOffset  = 3;        /// byte offset after successful header parsing
@@ -95,13 +93,11 @@ private:
 
     QByteArray m_dataBlock;                 /// Data buffer for parsing.
     int m_dataPos;                          /// bytecounter for running through the data packet.
-    quint32 m_messageType;                   /// Holding type of the actual message.
+    quint32 m_messageType;                  /// Holding type of the actual message.
 
     QHash<quint32, binDescriptor> m_typeToDescriptorMap;   /// hashMap storing a format descriptor for every message type
 
     QList<binDescriptor> m_descriptorForDeferredStorage; /// temp list for storing descriptors without a timestamp field
-
-    bool m_hasUnitData;                     /// True if parsed log contains unit data
 
     /**
      * @brief headerIsValid checks the first 2 start bytes
@@ -145,15 +141,6 @@ private:
      */
     bool parseDataByDescriptor(QList<NameValuePair> &NameValuePairList, const binDescriptor &desc);
 
-    /**
-     * @brief extendedStoreNameValuePairList checks for the unit data types (UNIT, MULT, FMTU)
-     *        and inserts them correctly into the datamodel. All other data will be passed to
-     *        the storeNameValuePairList() method of the base class
-     * @param NameValuePairList to be stored
-     * @param desc - matching descriptor for this NameValuePairList
-     * @return true success, false otherwise
-     */
-    bool extendedStoreNameValuePairList(QList<NameValuePair> &NameValuePairList, const typeDescriptor &desc);
 };
 
 #endif // BINLOGPARSER_H

--- a/src/ui/Loghandling/LogAnalysis.cpp
+++ b/src/ui/Loghandling/LogAnalysis.cpp
@@ -897,6 +897,7 @@ void LogAnalysis::itemEnabled(QString name)
 {
     QVector<double> xlist;
     QVector<double> ylist;
+
     if (!m_dataStoragePtr->getValues(name, m_useTimeOnXAxis, xlist, ylist))
     {
         //No values!
@@ -960,7 +961,6 @@ void LogAnalysis::itemEnabled(QString name)
     {
         QCPAxis *yAxis = m_plotPtr->axisRect()->axis(QCPAxis::atLeft, 1);
         yAxis->grid()->setVisible(false);
-//        connect(yAxis, SIGNAL(rangeChanged(QCPRange)), newPlot.p_yAxis, SLOT(setRange(QCPRange)));    // TODO really not needed???
     }
 
     m_plotPtr->replot();
@@ -1140,7 +1140,11 @@ void LogAnalysis::selectedRowChanged(QModelIndex current, QModelIndex previous)
         {
             // timestamp value of the current row is in colum 2
             double item = ui.tableWidget->model()->itemData(ui.tableWidget->model()->index(current.row(), 2)).value(Qt::DisplayRole).toInt();
-            mp_cursorSimple->setCurrentXPos(item / m_dataStoragePtr->getTimeDivisor());
+            if(!m_dataStoragePtr->ModelIsScaled())
+            {
+                // If datamodel is NOT scaled we have to scale the timestamp.
+                mp_cursorSimple->setCurrentXPos(item / m_dataStoragePtr->getTimeDivisor());
+            }
         }
         else
         {

--- a/src/ui/Loghandling/LogExporter.cpp
+++ b/src/ui/Loghandling/LogExporter.cpp
@@ -84,7 +84,7 @@ QString LogExporterBase::exportToFile(const QString &fileName, LogdataStorage::P
     QVector<QVariant> measurements;
     for(int i = 0; i < dataStoragePtr->rowCount(); ++i)
     {
-        dataStoragePtr->getDataRow(i, outputLine, measurements);
+        dataStoragePtr->getRawDataRow(i, outputLine, measurements);
         foreach(const QVariant &value, measurements)
         {
             outputLine.append(',');

--- a/src/ui/Loghandling/LogParserBase.h
+++ b/src/ui/Loghandling/LogParserBase.h
@@ -60,6 +60,10 @@ public:
 
 protected:
 
+    static const quint8 s_UNITMessageType = 0xE5; /// Type Id of the unit (UNIT) message
+    static const quint8 s_MULTMessageType = 0xE6; /// Type Id of the multiplier (MULT) message
+    static const quint8 s_FMTUMessageType = 0xE4; /// Type Id of the Format unit multiplier (FMTU) message
+
     /**
      * @brief The timeStampType struct
      *        Used to hold the name and the scaling of a time stamp.
@@ -109,7 +113,7 @@ protected:
          * @param oldName - name string to search for
          * @param newName - the new name to replace the old one
          */
-        virtual void replaceLabelName(const QString &oldName, const QString newName);
+        virtual void replaceLabelName(const QString &oldName, const QString &newName);
 
         virtual QString getLabelAtIndex(int index) const;
         virtual bool hasNoTimestamp() const;
@@ -136,6 +140,7 @@ protected:
     AP2DataPlotStatus m_logLoadingState;    /// State of the parser
 
     timeStampType m_activeTimestamp;        /// the detected timestamp used for parsing
+    bool m_hasUnitData;                     /// True if parsed log contains unit data
 
 
     /**
@@ -153,6 +158,16 @@ protected:
      * @return true - success, false - datamodel failure
      */
     bool storeNameValuePairList(QList<NameValuePair> &NameValuePairList, const typeDescriptor &desc);
+
+    /**
+     * @brief extendedStoreNameValuePairList checks for the unit data types (UNIT, MULT, FMTU)
+     *        and inserts them correctly into the datamodel. All other data will be passed to
+     *        the storeNameValuePairList() method.
+     * @param NameValuePairList to be stored
+     * @param desc - matching descriptor for this NameValuePairList
+     * @return true success, false otherwise
+     */
+    bool extendedStoreNameValuePairList(QList<NameValuePair> &NameValuePairList, const typeDescriptor &desc);
 
     /**
      * @brief handleTimeStamp does all time stamp handling. It checks if the time is increasing and

--- a/src/ui/Loghandling/LogdataStorage.cpp
+++ b/src/ui/Loghandling/LogdataStorage.cpp
@@ -162,7 +162,7 @@ QVariant LogdataStorage::headerData(int column, Qt::Orientation orientation, int
 }
 
 bool LogdataStorage::addDataType(const QString &typeName, quint32 typeID, int typeLength,
-                                 const QString &typeFormat, const QStringList &typeLabels, int timeColum)
+                                 const QString &typeFormat, const QStringList &typeLabels, int timeColumn)
 {
     // set up column count - the storage adds s_ColumnOffset columns to the data.
     // One for the index and one for the name.
@@ -394,6 +394,24 @@ void LogdataStorage::getRawDataRow(int index, QString &name, QVector<QVariant> &
     }
 }
 
+QHash<quint8, QString> LogdataStorage::getUnitData() const
+{
+    return m_unitStorage;
+}
+
+QHash<quint8, double> LogdataStorage::getMultiplierData() const
+{
+    return m_multiplierStorage;
+}
+
+QPair<QByteArray, QByteArray> LogdataStorage::getMsgToUnitAndMultiplierData(quint32 typeID) const
+{
+    QPair<QByteArray, QByteArray> dataPair;
+
+    dataPair.first  = m_typeIDToMultiplierFieldInfo[typeID];
+    dataPair.second = m_typeIDToUnitFieldInfo[typeID];
+    return dataPair;
+}
 
 double LogdataStorage::getMinTimeStamp() const
 {

--- a/src/ui/Loghandling/LogdataStorage.h
+++ b/src/ui/Loghandling/LogdataStorage.h
@@ -73,7 +73,7 @@ public:
         {}
 
         dataType(const QString &name, quint32 ID, int length,
-                 const QString &format, const QStringList &labels, int timeColum) :
+                 const QString &format, const QStringList &labels, int timeColumn) :
             m_name(name), m_ID(ID), m_length(length),
             m_format(format), m_labels(labels), m_timeStampIndex(timeColumn)
         {}
@@ -124,13 +124,13 @@ public:
      * @param typeID - ID of the type to ba added
      * @param typeLength - Length of the type to ba added (bytes)
      * @param typeFormat - format string like "QbbI"
-     * @param typeLabels - List of labels for each value in message (colums).
+     * @param typeLabels - List of labels for each value in message (columns).
      * @param timeColumn - column index of the time stamp field
      *
      * @return - true success, false otherwise (data was not added)
      */
     virtual bool addDataType(const QString &typeName, quint32 typeID, int typeLength,
-                             const QString &typeFormat, const QStringList &typeLabels, int timeColum);
+                             const QString &typeFormat, const QStringList &typeLabels, int timeColumn);
 
     /**
      * @brief addDataRow adds a data row - a list of pairs of string and value - to the data storage.
@@ -242,6 +242,30 @@ public:
     virtual void getRawDataRow(int index, QString &name, QVector<QVariant> &measurements) const;
 
     /**
+     * @brief getUnitData - returns the unit data stored in model. Can be empty if no unit data
+     *        available. Used for exporting.
+     * @return - container holding id to unit data. As the order is not important we just use the
+     *           same format as in datamodel.
+     */
+    virtual QHash<quint8, QString> getUnitData() const;
+
+    /**
+     * @brief getMultiplierData - returns the multiplier data stored in model. Can be empty if no multiplier data
+     *        available. Used for exporting.
+     * @return - container holding id to multiplier data. As the order is not important we just use the
+     *           same format as in datamodel.
+     */
+    virtual QHash<quint8, double> getMultiplierData() const;
+
+    /**
+     * @brief getMsgToUnitAndMultiplierData - returns the unit and the multiplier indexes used by a special
+     *        message type
+     * @param typeID - message type ID to get the data for
+     * @return - mulriplier and unit data for the requested message ID
+     */
+    virtual QPair<QByteArray, QByteArray> getMsgToUnitAndMultiplierData(quint32 typeID) const;
+
+    /**
      * @brief getMinTimeStamp - getter for the smallest timestamp in log
      * @return - the smallest timestamp scaled to seconds
      */
@@ -344,8 +368,8 @@ private:
 
     QHash<quint8, QString> m_unitStorage;           /// Holds UNIT data and unit id (if available)
     QHash<quint8, double>  m_multiplierStorage;     /// Holds Multiplier data and multiplier id (if available)
-    QHash<unsigned int, QByteArray> m_typeIDToUnitFieldInfo;       /// Holds Unit IDs for every type
-    QHash<unsigned int, QByteArray> m_typeIDToMultiplierFieldInfo; /// Holds Multiplier IDs for every type
+    QHash<quint32, QByteArray> m_typeIDToUnitFieldInfo;       /// Holds Unit IDs for every type
+    QHash<quint32, QByteArray> m_typeIDToMultiplierFieldInfo; /// Holds Multiplier IDs for every type
 
 
     /**

--- a/src/ui/Loghandling/TlogParser.cpp
+++ b/src/ui/Loghandling/TlogParser.cpp
@@ -244,7 +244,7 @@ bool TlogParser::parseDescriptor(tlogDescriptor &desc)
             {
                 extractDescriptorDataFields(desc, fieldinfo, "I", 4);
             }
-                break;
+            break;
             case MAVLINK_TYPE_INT32_T:
             {
                 extractDescriptorDataFields(desc, fieldinfo, "i", 4);
@@ -286,6 +286,7 @@ void TlogParser::extractDescriptorDataFields(tlogDescriptor &desc, const mavlink
 {
     if(fieldInfo.array_length == 0)
     {
+        // extract single value
         desc.m_labels.push_back(fieldInfo.name);
         desc.m_format += format;
         desc.m_length += size;
@@ -294,6 +295,7 @@ void TlogParser::extractDescriptorDataFields(tlogDescriptor &desc, const mavlink
     {
         for (unsigned int i = 0; i < fieldInfo.array_length; ++i)
         {
+            // extract array value
             QString name(fieldInfo.name);
             name.append('-');
             name.append(QString::number(i));
@@ -342,7 +344,7 @@ bool TlogParser::decodeData(const mavlink_message_t &mavlinkMessage, QList<NameV
     return success;
 }
 
-void TlogParser::newValue(const int uasId, const QString &name, const QString &unit, const QVariant &value, const quint64 msec)
+void TlogParser::newValue(int uasId, const QString &name, const QString &unit, const QVariant &value, quint64 msec)
 {
     Q_UNUSED(uasId);
     Q_UNUSED(msec);

--- a/src/ui/Loghandling/TlogParser.h
+++ b/src/ui/Loghandling/TlogParser.h
@@ -71,7 +71,7 @@ public:
      * @param value - the value itself
      * @param msec  - some sort of timestamp
      */
-    void newValue(const int uasId, const QString &name, const QString &unit, const QVariant &value, const quint64 msec);
+    void newValue(int uasId, const QString &name, const QString &unit, const QVariant &value, quint64 msec);
 
     /**
      * @brief newTextValue - Callback for the mavlink decoder - called for every decoded string


### PR DESCRIPTION
This PR adds unit support to flashlog parser and to the datastorage. Flashlogs provided by the upcoming arducopter 3.6 provide unit information so all data can be scaled properly.
It solves #1089