### PR TITLE
GraphView: Message IDs for Unit data are now setup dynamically.

### DIFF
--- a/src/ui/Loghandling/AsciiLogParser.cpp
+++ b/src/ui/Loghandling/AsciiLogParser.cpp
@@ -106,12 +106,8 @@ AP2DataPlotStatus AsciiLogParser::parse(QFile &logfile)
                 asciiDescriptor descriptor;
                 if(parseFMTMessage(descriptor))
                 {
-                    if(descriptor.m_name == "GPS" && !descriptor.m_labels.contains("GPSTimeMS"))
-                    {
-                        // Special handling for "GPS" messages that have a "TimeMS"
-                        // timestamp but scaling and value does not mach all other time stamps
-                        descriptor.replaceLabelName("TimeMS", "GPSTimeMS");
-                    }
+                    // do some special handling if needed
+                    specialDescriptorHandling(descriptor);
                     if(m_activeTimestamp.valid())
                     {
                         descriptor.finalize(m_activeTimestamp);

--- a/src/ui/Loghandling/BinLogParser.cpp
+++ b/src/ui/Loghandling/BinLogParser.cpp
@@ -112,12 +112,8 @@ AP2DataPlotStatus BinLogParser::parse(QFile &logfile)
                 binDescriptor descriptor;
                 if(parseFMTMessage(descriptor))
                 {
-                    if(descriptor.m_name == "GPS")
-                    {
-                        // Special handling for "GPS" messages that have a "TimeMS"
-                        // timestamp but scaling and value does not mach all other time stamps
-                        descriptor.replaceLabelName("TimeMS", "GPSTimeMS");
-                    }
+                    // do some special handling if needed
+                    specialDescriptorHandling(descriptor);
                     if(m_activeTimestamp.valid())
                     {
                         descriptor.finalize(m_activeTimestamp);

--- a/src/ui/Loghandling/LogParserBase.h
+++ b/src/ui/Loghandling/LogParserBase.h
@@ -60,10 +60,6 @@ public:
 
 protected:
 
-    static const quint8 s_UNITMessageType = 0xE5; /// Type Id of the unit (UNIT) message
-    static const quint8 s_MULTMessageType = 0xE6; /// Type Id of the multiplier (MULT) message
-    static const quint8 s_FMTUMessageType = 0xE4; /// Type Id of the Format unit multiplier (FMTU) message
-
     /**
      * @brief The timeStampType struct
      *        Used to hold the name and the scaling of a time stamp.
@@ -140,6 +136,11 @@ protected:
     AP2DataPlotStatus m_logLoadingState;    /// State of the parser
 
     timeStampType m_activeTimestamp;        /// the detected timestamp used for parsing
+
+    quint32 m_idUnitMessage;                /// to store the Type Id of the unit (UNIT) message
+    quint32 m_idMultMessage;                /// to store the Type Id of the multiplier (MULT) message
+    quint32 m_idFMTUMessage;                /// to store the Type Id of the Format unit multiplier (FMTU) message
+
     bool m_hasUnitData;                     /// True if parsed log contains unit data
 
 
@@ -201,6 +202,13 @@ protected:
      * @return - valid time stamp
      */
     quint64 nextValidTimestamp();
+
+    /**
+     * @brief specialDescriptorHandling does some extra handling for speial descriptor. As some
+     *        message types need special treatment and / or deliver special information they can
+     *        be handled inside this method.
+     */
+    void specialDescriptorHandling(typeDescriptor &desc);
 
 
 private:


### PR DESCRIPTION
The old unit handling code had static defines for UNIT, MULT and FMTU messages, but the message ID of this messages are dynamic and can change.
Now the message IDs of this messages are set up while parsing.