### PR TITLE
read and request int32 waypoints

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -1052,14 +1052,26 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
         }
             break;
 
-        case MAVLINK_MSG_ID_MISSION_ITEM:
+        // add MAV Message id: MAVLINK_MSG_ID_MISSION_ITEM_INT
+        // to handle the mavlink_mission_item_int_t type message
+        case MAVLINK_MSG_ID_MISSION_ITEM_INT:
         {
-            mavlink_mission_item_t wp;
-            mavlink_msg_mission_item_decode(&message, &wp);
-            //QLOG_DEBUG() << "got waypoint (" << wp.seq << ") from ID " << message.sysid << " x=" << wp.x << " y=" << wp.y << " z=" << wp.z;
+            mavlink_mission_item_int_t wp;
+            // using mavlink_msg_mission_item_int_decode to decode mavlink_mission_item_int_t type message
+            mavlink_msg_mission_item_int_decode(&message, &wp);
             waypointManager.handleWaypoint(message.sysid, message.compid, &wp);
         }
             break;
+
+        // unable to support float waypoints
+//        case MAVLINK_MSG_ID_MISSION_ITEM:
+//        {
+//            mavlink_mission_item_t wp;
+//            mavlink_msg_mission_item_decode(&message, &wp);
+//            //QLOG_DEBUG() << "got waypoint (" << wp.seq << ") from ID " << message.sysid << " x=" << wp.x << " y=" << wp.y << " z=" << wp.z;
+//            waypointManager.handleWaypoint(message.sysid, message.compid, &wp);
+//        }
+//            break;
 
         case MAVLINK_MSG_ID_MISSION_ACK:
         {

--- a/src/uas/UASWaypointManager.h
+++ b/src/uas/UASWaypointManager.h
@@ -72,7 +72,7 @@ public:
     /** @name Received message handlers */
     /*@{*/
     void handleWaypointCount(quint8 systemId, quint8 compId, quint16 count);                            ///< Handles received waypoint count messages
-    void handleWaypoint(quint8 systemId, quint8 compId, mavlink_mission_item_t *wp);                        ///< Handles received waypoint messages
+    void handleWaypoint(quint8 systemId, quint8 compId, mavlink_mission_item_int_t *wp);                        ///< Handles received waypoint int messages
     void handleWaypointAck(quint8 systemId, quint8 compId, mavlink_mission_ack_t *wpa);                ///< Handles received waypoint ack messages
     void handleWaypointRequest(quint8 systemId, quint8 compId, mavlink_mission_request_t *wpr);        ///< Handles received waypoint request messages
     void handleWaypointReached(quint8 systemId, quint8 compId, mavlink_mission_item_reached_t *wpr);        ///< Handles received waypoint reached messages
@@ -181,7 +181,8 @@ private:
     QList<Waypoint *> waypointsViewOnly;                  ///< local copy of current waypoint list on MAV
     QList<Waypoint *> waypointsEditable;                  ///< local editable waypoint list
     Waypoint* currentWaypointEditable;                      ///< The currently used waypoint
-    QList<mavlink_mission_item_t *> waypoint_buffer;  ///< buffer for waypoints during communication
+    // change from mavlink_mission_item_t to mavlink_mission_item_int_t
+    QList<mavlink_mission_item_int_t *> waypoint_buffer;  ///< buffer for waypoints during communication
     QTimer protocol_timer;                          ///< Timer to catch timeouts
     bool standalone;                                ///< If standalone is set, do not write to UAS
     quint16 uasid;


### PR DESCRIPTION
Hello APM Planner developers,

I found a problem that the waypoints drawn on the map are not accurate. According to this post: https://discuss.ardupilot.org/t/inaccurate-waypoint-logging-with-toggle-switch/26636, I believed that the error come from the conversion from float to double value. APM Planner requests and write waypoints gps position  in float, however, the Ardupilot system uses int32 to store the gps position for waypoints in default. So I changed the source code to make APM Planner request and write each waypoints in int32. The message ID for the mission item, which contains waypoint ID, should be MAVLINK_MSG_ID_MISSION_ITEM_INT rather than the MAVLINK_MSG_ID_MISSION_ITEM, and the mission item type should be mavlink_mission_item_int_t instead of mavlink_mission_item_t.