### PR TITLE
Enable set home

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -904,13 +904,26 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
             setSatelliteCount(pos.satellites_visible);
         }
             break;
+
         case MAVLINK_MSG_ID_GPS_GLOBAL_ORIGIN:
         {
-            mavlink_gps_global_origin_t pos;
-            mavlink_msg_gps_global_origin_decode(&message, &pos);
-            emit homePositionChanged(uasId, pos.latitude / 10000000.0, pos.longitude / 10000000.0, pos.altitude / 1000.0);
-        }
+            //mavlink_gps_global_origin_t pos;
+            //mavlink_msg_gps_global_origin_decode(&message, &pos);
+            // Origin means the position where UAV came alive eg. its first valid GPS position. This position can be different from home
+            // position.
+            //emit homePositionChanged(uasId, pos.latitude / 10000000.0, pos.longitude / 10000000.0, pos.altitude / 1000.0);
             break;
+        }
+
+        case MAVLINK_MSG_ID_HOME_POSITION:
+        {
+            // Home position is where the UAV will return to when return home is triggered. All UAVs share the home position.
+            mavlink_home_position_t pos;
+            mavlink_msg_home_position_decode(&message, &pos);
+            emit homePositionChanged(uasId, pos.latitude / 10000000.0, pos.longitude / 10000000.0, pos.altitude / 1000.0);
+            break;
+        }
+
         case MAVLINK_MSG_ID_RC_CHANNELS:
         {
             mavlink_rc_channels_t channels;
@@ -942,6 +955,7 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
 
             break;
         }
+
         case MAVLINK_MSG_ID_RC_CHANNELS_RAW:
         {
             mavlink_rc_channels_raw_t channels;

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -897,21 +897,24 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
         {
             mavlink_gps_status_t pos;
             mavlink_msg_gps_status_decode(&message, &pos);
-            for(int i = 0; i < (int)pos.satellites_visible; i++)
+            for(int i = 0; i < pos.satellites_visible; i++)
             {
-                emit gpsSatelliteStatusChanged(uasId, (unsigned char)pos.satellite_prn[i], (unsigned char)pos.satellite_elevation[i], (unsigned char)pos.satellite_azimuth[i], (unsigned char)pos.satellite_snr[i], static_cast<bool>(pos.satellite_used[i]));
+                emit gpsSatelliteStatusChanged(uasId, pos.satellite_prn[i], static_cast<float>(pos.satellite_elevation[i]), static_cast<float>(pos.satellite_azimuth[i]), static_cast<float>(pos.satellite_snr[i]), static_cast<bool>(pos.satellite_used[i]));
             }
             setSatelliteCount(pos.satellites_visible);
-        }
             break;
+        }
 
         case MAVLINK_MSG_ID_GPS_GLOBAL_ORIGIN:
         {
-            //mavlink_gps_global_origin_t pos;
-            //mavlink_msg_gps_global_origin_decode(&message, &pos);
-            // Origin means the position where UAV came alive eg. its first valid GPS position. This position can be different from home
-            // position.
-            //emit homePositionChanged(uasId, pos.latitude / 10000000.0, pos.longitude / 10000000.0, pos.altitude / 1000.0);
+            // Origin means the position where UAV came alive eg. its first valid GPS position.
+            // This position can be different from home position. Each UAV has its own origin.
+            mavlink_gps_global_origin_t pos;
+            mavlink_msg_gps_global_origin_decode(&message, &pos);
+            m_originLatitude  = pos.latitude / 10000000.0;
+            m_originLongitude = pos.longitude / 10000000.0;
+            m_originAltitude  = pos.altitude / 1000.0f;
+            m_originValid     = true;
             break;
         }
 

--- a/src/uas/UAS.h
+++ b/src/uas/UAS.h
@@ -283,7 +283,7 @@ public:
         return velocity_gps;
     }
 
-    void setSatelliteCount(double val)
+    void setSatelliteCount(int val)
     {
         m_satelliteCount = val;
         emit satelliteCountChanged(val,"satelliteCount");
@@ -510,6 +510,11 @@ protected: //COMMENTS FOR TEST UNIT
     double speedX;              ///< True speed in X axis
     double speedY;              ///< True speed in Y axis
     double speedZ;              ///< True speed in Z axis
+
+    bool m_originValid      {false};    ///< True if origin position is valid.
+    double m_originLatitude {0.0};      ///< Origin position latitude.
+    double m_originLongitude{0.0};      ///< Origin position longitude.
+    float  m_originAltitude {0.0};      ///< Origin position altitude.
 
     QVector3D nedPosGlobalOffset;   ///< Offset between the system's NED position measurements and the swarm / global 0/0/0 origin
     QVector3D nedAttGlobalOffset;   ///< Offset between the system's NED position measurements and the swarm / global 0/0/0 origin

--- a/src/ui/map/QGCMapWidget.cc
+++ b/src/ui/map/QGCMapWidget.cc
@@ -623,6 +623,8 @@ void QGCMapWidget::updateHomePosition(double latitude, double longitude, double 
     Home->SetAltitude(altitude);
     homeAltitude = altitude;
     SetShowHome(true);                      // display the HOME position on the map
+
+    Home->RefreshPos();     // Force repainting
 }
 
 void QGCMapWidget::goHome()


### PR DESCRIPTION
When receiving MAVLINK_MSG_ID_HOME_POSITION the UAV home position on map will be updated. The MAVLINK_MSG_ID_GPS_GLOBAL_ORIGIN reception will only store the position but will not bet treated as home pos anymore. 