### PR TITLE
mavlink: support both MISSION_REQUEST and MISSION_REQUEST_INT

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -1098,6 +1098,14 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
         }
             break;
 
+        case MAVLINK_MSG_ID_MISSION_REQUEST_INT:
+        {
+            mavlink_mission_request_int_t wpr;
+            mavlink_msg_mission_request_int_decode(&message, &wpr);
+            waypointManager.handleWaypointRequest(message.sysid, message.compid, &wpr);
+        }
+            break;
+
         case MAVLINK_MSG_ID_MISSION_REQUEST:
         {
             mavlink_mission_request_t wpr;

--- a/src/uas/UASWaypointManager.cc
+++ b/src/uas/UASWaypointManager.cc
@@ -1099,7 +1099,11 @@ void UASWaypointManager::sendWaypoint(quint16 seq)
             convertMavlinkMissionItem(wp, &wp_float);
             mavlink_msg_mission_item_encode(uas->getSystemId(), uas->getComponentId(), &message, &wp_float);
         }
-        else return;
+        else {
+            QLOG_DEBUG() << "sendWaypoint() - Current state does not allow sending waypoints. Check failed: current_state: " << current_state
+                         << " == " << WP_SENDLIST_SENDWPSINT << " or " << WP_SENDLIST_SENDWPSFLOAT;
+            return;
+        }
 
         emit updateStatusString(QString("Sending waypoint ID %1 of %2 total").arg(wp->seq).arg(current_count));
         uas->sendMessage(message);


### PR DESCRIPTION
#1179 added support for integer waypoints. However, the code does not distinguish between a MAVLink MISSION_REQUEST and MISSION_REQUEST_INT.

I added this feature here. @Arne-W and @niuxw What do you think?