### PR TITLE
ui: Radio3DRSettings: don't use qAsConst

### DIFF
--- a/src/ui/configuration/Radio3DRSettings.cc
+++ b/src/ui/configuration/Radio3DRSettings.cc
@@ -121,7 +121,7 @@ bool Radio3DREeprom::setVersion(const QString &versionString)
     QLOG_DEBUG() << "Radio Firmware:" << versionString;
 
     QString vers;
-    for (const QChar c : qAsConst(versionString)) {
+    for (const QChar c : versionString) {
     if (c.isDigit() || c == '.') {
     vers.append(c);
   }


### PR DESCRIPTION
This doesn't work trivially on either of Xenial64 or Bionic64 installs
