### PR TITLE
Added mission type to MAVLink mission_count message

### DIFF
--- a/src/uas/UASWaypointManager.cc
+++ b/src/uas/UASWaypointManager.cc
@@ -1034,6 +1034,7 @@ void UASWaypointManager::sendWaypointCount()
     wpc.target_system = uasid;
     wpc.target_component = MAV_COMP_ID_MISSIONPLANNER;
     wpc.count = current_count;
+    wpc.mission_type = MAV_MISSION_TYPE_MISSION;
 
     emit updateStatusString(QString("Starting to transmit waypoints..."));
 


### PR DESCRIPTION
This pull request fixes the following bug:

While uploading the waypoints to the UAS, a `mission_count` message is sent. The struct `mavlink_mission_count_t` has a field `mission_type`, which was not set and therefore had a random value (so in most cases 0). You can find the possible values in [MAVLink's common.h](https://github.com/ArduPilot/apm_planner/blob/master/libs/mavlink/include/mavlink/v2.0/common/common.h#L664-L666). I set it to `MAV_MISSION_TYPE_MISSION`.

Best,
Dino