### PR TITLE
Allow MAV_CMD with values > 255

### DIFF
--- a/src/ui/mission/QGCMissionOther.cc
+++ b/src/ui/mission/QGCMissionOther.cc
@@ -7,6 +7,7 @@ QGCMissionOther::QGCMissionOther(WaypointEditableView* WEV) :
     ui(new Ui::QGCMissionOther)
 {
     ui->setupUi(this);
+    ui->commandSpinBox->setMaximum(MAV_CMD_ENUM_END-1);
     this->WEV = WEV;
     //Using UI to change WP:
     connect(this->ui->commandSpinBox,SIGNAL(valueChanged(int)),WEV,SLOT(changedCommand(int)));


### PR DESCRIPTION
The new MAVLink version uses an [uint16 to store commands](https://github.com/ArduPilot/apm_planner/blob/master/libs/mavlink/include/mavlink/v2.0/common/mavlink_msg_mission_item.h#L16) (`MAV_CMD`). However, in the current master the value for commands is [limited to 255](https://github.com/ArduPilot/apm_planner/blob/master/src/ui/mission/QGCMissionOther.ui#L53). This pull request sets it to [the maximum allowable value](https://github.com/ArduPilot/apm_planner/blob/master/libs/mavlink/include/mavlink/v2.0/ardupilotmega/ardupilotmega.h#L215).