### PR TITLE
Firmware Install : Work around non-instant modem availability for PX4

### DIFF
--- a/src/ui/configuration/PX4FirmwareUploader.cc
+++ b/src/ui/configuration/PX4FirmwareUploader.cc
@@ -289,9 +289,17 @@ void PX4FirmwareUploader::kickOffTriggered()
     m_port->setPortName(m_portToUse);
 #endif
 
-    if (!m_port->open(QIODevice::ReadWrite))
-    {
-        QLOG_ERROR() << "Unable to open port:" << m_port->errorString();
+    for (int t = 0; t < 100; ++t) {
+        if (!m_port->open(QIODevice::ReadWrite))
+        {
+            auto errorString = m_port->errorString();
+            QLOG_ERROR() << "Unable to open port, attempt " << t << ":" << errorString;
+            sleep(1);
+        }
+        else
+        {
+            break;
+        }
     }
     m_port->write(QByteArray().append(0x21).append(0x20));
 


### PR DESCRIPTION
During firmware updates, one is typically requested to replug the device.

On my system, the newly inserted device is nearly immediately detected by the planner, but the permissions on that device are not immediately set the right way (probably because `mtp-probe` needs to check it first). For this reason, firmware flashing is basically impossible.

This pull request introduces waiting for the device to become available with one-second sleeps between the attempts. While this is a dirty-ish hack, and something should have maybe done project-wide instead, I am not confident enough to do that. The introduced change just works for my use case, and is extremely unlikely to break anything.

This may probably fix #731, if I have guessed right which subsystem is responsible for that issue.