### PR TITLE
General: Allow changing the Mavlink ID of APM Planner in advanced config dialog. Fixes #1228

### DIFF
--- a/src/QGC.h
+++ b/src/QGC.h
@@ -61,7 +61,7 @@
 
 namespace QGC
 {
-const static int defaultSystemId = 252; // Using 252 to 'crudely' identify a log created by APM Planner 2
+
 const static int defaultComponentId = MAV_COMP_ID_PRIMARY; // The main component ID is 1 for autopilot/and GCS (0 means all components)
 
 const QColor colorCyan(55, 154, 195);

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -39,14 +39,9 @@ This file is part of the APM_PLANNER project
 #include <cstring>
 #include <QDataStream>
 
-MAVLinkProtocol::MAVLinkProtocol():
-    m_isOnline(true),
-    m_loggingEnabled(false),
-    m_throwAwayGCSPackets(false),
-    m_connectionManager(nullptr),
-    versionMismatchIgnore(false),
-    m_enable_version_check(false)
+MAVLinkProtocol::MAVLinkProtocol()
 {
+    m_systemID = QGC::MavlinkID();
 }
 
 MAVLinkProtocol::~MAVLinkProtocol()
@@ -56,7 +51,7 @@ MAVLinkProtocol::~MAVLinkProtocol()
 
 void MAVLinkProtocol::sendMessage(mavlink_message_t msg)
 {
-    Q_UNUSED(msg);
+    Q_UNUSED(msg)
 }
 
 void MAVLinkProtocol::receiveBytes(LinkInterface* link, const QByteArray &dataBytes)
@@ -161,7 +156,7 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, const QByteArray &dataBy
                 if(!ping.target_system && !ping.target_component && m_isOnline)
                 {
                     mavlink_message_t msg;
-                    mavlink_msg_ping_pack(s_SystemID, s_ComponentID, &msg, ping.time_usec, ping.seq, message.sysid, message.compid);
+                    mavlink_msg_ping_pack(m_systemID, m_componentID, &msg, ping.time_usec, ping.seq, message.sysid, message.compid);
                     sendMessage(msg);
                 }
             }
@@ -269,14 +264,14 @@ void MAVLinkProtocol::handleMessage(LinkInterface *link, const mavlink_message_t
         // it's first messages.
 
         // Check if the UAS has the same id like this system
-        if (message.sysid == s_SystemID)
+        if (message.sysid == m_systemID)
         {
             if (m_throwAwayGCSPackets)
             {
                 //If replaying, we have to assume that it's just hearing ground control traffic
                 return;
             }
-            emit protocolStatusMessage(tr("SYSTEM ID CONFLICT!"), tr("Warning: A second system is using the same system id (%1)").arg(s_SystemID));
+            emit protocolStatusMessage(tr("SYSTEM ID CONFLICT!"), tr("Warning: A second system is using the same system id (%1)").arg(m_systemID));
         }
 
         // Create a new UAS based on the heartbeat received

--- a/src/comm/MAVLinkProtocol.h
+++ b/src/comm/MAVLinkProtocol.h
@@ -53,8 +53,6 @@ class MAVLinkProtocol : public QObject
     Q_OBJECT
 
 public:
-    constexpr static quint8 s_SystemID    = 252;
-    constexpr static quint8 s_ComponentID = 1;
 
     explicit MAVLinkProtocol();
     ~MAVLinkProtocol();
@@ -71,19 +69,23 @@ public slots:
 
 private:
     void handleMessage(LinkInterface *link, const mavlink_message_t &message);
-    bool m_isOnline;
-    bool m_loggingEnabled;
+
+    quint8 m_systemID    = QGC::defaultMavlinkSystemId;
+    quint8 m_componentID = QGC::defaultComponentId;
+
+    bool m_isOnline = true;
+    bool m_loggingEnabled = true;
     QScopedPointer<QFile>m_ScopedLogfilePtr;
 
-    bool m_throwAwayGCSPackets;
-    LinkManager *m_connectionManager;
-    bool versionMismatchIgnore;
+    bool m_throwAwayGCSPackets = false;
+    LinkManager *m_connectionManager = nullptr;
+    bool versionMismatchIgnore = false;
     QMap<int, qint64> totalReceiveCounter;
     QMap<int, qint64> currReceiveCounter;
     QMap<int,QMap<int, quint8> > lastIndex;
     QMap<int, qint64> totalLossCounter;
     QMap<int, qint64> currLossCounter;
-    bool m_enable_version_check;
+    bool m_enable_version_check = false;
 
 signals:
     void protocolStatusMessage(const QString& title, const QString& message);

--- a/src/comm/TLogReplayLink.cc
+++ b/src/comm/TLogReplayLink.cc
@@ -214,7 +214,7 @@ void TLogReplayLink::run()
             {
                 nexttime = true;
                 //Good decode
-                if (message.sysid == 255)
+                if (message.sysid == QGC::MavlinkID())
                 {
                     //GCS packet, ignore it
                 }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -58,14 +58,15 @@
 namespace QGC
 
 {
-const QString APPNAME = "APMPLANNER2";
-const QString COMPANYNAME = "ARDUPILOT";
-const int APPLICATIONVERSION = 2028; // 2.0.28 [TODO] we should deprecate this version definition
+const static QString APPNAME = "APMPLANNER2";
+const static QString COMPANYNAME = "ARDUPILOT";
+const static int APPLICATIONVERSION = 2028; // 2.0.28 [TODO] we should deprecate this version definition
+const static quint8 defaultMavlinkSystemId = 252; // Using 252 to 'crudely' identify a log created by APM Planner 2
 
     inline void close(){
         GlobalObject* global = GlobalObject::sharedInstance();
         delete global;
-        global = NULL;
+        global = nullptr;
     }
 
     inline void loadSettings(){
@@ -123,6 +124,15 @@ const int APPLICATIONVERSION = 2028; // 2.0.28 [TODO] we should deprecate this v
     inline void setMissionDirectory(const QString& dir){
         GlobalObject::sharedInstance()->setMissionDirectory(dir);
     }
+
+    inline quint8 MavlinkID(){
+        return GlobalObject::sharedInstance()->MavlinkID();
+    }
+
+    inline void setMavlinkID(const quint8 ID){
+        GlobalObject::sharedInstance()->setMavlinkID(ID);
+    }
+
 
     //Returns the absolute parth to the files, data, qml support directories
     //It could be in 1 of 2 places under Linux

--- a/src/globalobject.cc
+++ b/src/globalobject.cc
@@ -8,7 +8,7 @@
 
 GlobalObject* GlobalObject::sharedInstance()
 {
-    static GlobalObject* _globalInstance = NULL;
+    static GlobalObject* _globalInstance = nullptr;
     if (_globalInstance) {
         return _globalInstance;
     }
@@ -35,6 +35,7 @@ void GlobalObject::loadSettings()
     m_MAVLinklogDirectory = settings.value("MAVLINK_LOG_DIRECTORY", defaultMAVLinkLogDirectory()).toString();
     m_parameterDirectory = settings.value("PARAMETER_DIRECTORY", defaultParameterDirectory()).toString();
     m_missionDirectory = settings.value("MISSION_DIRECTORY", defaultMissionDirectory()).toString();
+    m_mavlinkID = static_cast<quint8>(settings.value("MAVLINK_ID", defaultMavlinkID()).toUInt());
 
     settings.endGroup();
 }
@@ -49,6 +50,7 @@ void GlobalObject::saveSettings()
     QLOG_DEBUG() << "save tlog dir to:" << m_MAVLinklogDirectory;
     settings.setValue("PARAMETER_DIRECTORY", m_parameterDirectory);
     settings.setValue("MISSION_DIRECTORY", m_missionDirectory);
+    settings.setValue("MAVLINK_ID", m_mavlinkID);
 
     settings.sync();
 }
@@ -183,6 +185,26 @@ void GlobalObject::setMissionDirectory(const QString &dir)
     QLOG_DEBUG() << "Set mission dir to:" << dir;
     m_missionDirectory = dir;
 }
+
+//
+// Mavlink ID of APM PLanner
+//
+
+quint8 GlobalObject::defaultMavlinkID()
+{
+    return QGC::defaultMavlinkSystemId;
+}
+
+quint8 GlobalObject::MavlinkID()
+{
+    return m_mavlinkID;
+}
+
+void GlobalObject::setMavlinkID(const quint8 mavlinkID)
+{
+    m_mavlinkID = mavlinkID;
+}
+
 
 //
 // Share Directory

--- a/src/globalobject.h
+++ b/src/globalobject.h
@@ -68,6 +68,10 @@ public:
     QString missionDirectory();
     void setMissionDirectory(const QString &dir);
 
+    quint8 defaultMavlinkID();
+    quint8 MavlinkID();
+    void setMavlinkID(const quint8 mavlinkID);
+
     QString shareDirectory();
 
 private:
@@ -78,6 +82,7 @@ private:
     QString m_MAVLinklogDirectory;
     QString m_parameterDirectory;
     QString m_missionDirectory;
+    quint8  m_mavlinkID;
 
 };
 

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -176,9 +176,9 @@ UAS::UAS(MAVLinkProtocol* protocol, int id) : UASInterface(),
     readSettings(); 
     // Initial signals
     emit disarmed();
-    emit armingChanged(false);  
+    emit armingChanged(false);
 
-    systemId = QGC::defaultSystemId;
+    systemId = QGC::MavlinkID();
     componentId = QGC::defaultComponentId;
 
     m_heartbeatsEnabled = MainWindow::instance()->heartbeatEnabled(); //Default to sending heartbeats

--- a/src/ui/Loghandling/TlogParser.cpp
+++ b/src/ui/Loghandling/TlogParser.cpp
@@ -101,7 +101,7 @@ AP2DataPlotStatus TlogParser::parse(QFile &logfile)
 
                 tlogDescriptor descriptor;
                 descriptor.m_name = m_mavDecoderPtr->getMessageName(mavlinkMessage.msgid);
-                if ((descriptor.m_name != "EMPTY") && (mavlinkMessage.sysid != s_GCSType))
+                if (descriptor.m_name != "EMPTY")
                 {
                     descriptor.m_ID = mavlinkMessage.msgid;
                     if(!m_nameToDescriptorMap.contains(descriptor.m_name))

--- a/src/ui/Loghandling/TlogParser.h
+++ b/src/ui/Loghandling/TlogParser.h
@@ -53,7 +53,7 @@ public:
     /**
      * @brief ~TlogParser - DTOR
      */
-    virtual ~TlogParser();
+    virtual ~TlogParser() override;
 
     /**
      * @brief parse method reads the logfile. Should be called with an
@@ -61,7 +61,7 @@ public:
      * @param logfile - The file which should be parsed
      * @return - Detailed status of the parsing
      */
-    virtual AP2DataPlotStatus parse(QFile &logfile);
+    virtual AP2DataPlotStatus parse(QFile &logfile) override;
 
     /**
      * @brief newValue - Callback for the mavlink decoder - called for every decoded value
@@ -84,8 +84,6 @@ public:
 
 private:
 
-    static const quint8 s_GCSType = 255;  /// sys id of Ground station
-
     /**
      * @brief The tlogDescriptor class provides a specialized typeDescriptor
      *        with an own isValid method.
@@ -93,7 +91,7 @@ private:
     class tlogDescriptor : public typeDescriptor
     {
     public:
-        virtual bool isValid() const;
+        virtual bool isValid() const override;
     };
 
     QHash<QString, tlogDescriptor> m_nameToDescriptorMap;   /// hashMap storing a format descriptor for every message type
@@ -105,6 +103,8 @@ private:
     quint8 m_lastModeVal;       /// holds the current mode used to detect changes
 
     QList<NameValuePair> *mp_ReceiveData;  /// pointer to the data structure for receiving data
+
+    quint8 m_GCSMavID = QGC::MavlinkID();  /// sys id of Ground station
 
     /**
      * @brief addMissingDescriptors adds the missing type descriptors to the

--- a/src/ui/QGCSettingsWidget.cc
+++ b/src/ui/QGCSettingsWidget.cc
@@ -107,6 +107,9 @@ void QGCSettingsWidget::showEvent(QShowEvent *evt)
         connect(ui->rcChannelDataLineEdit, SIGNAL(editingFinished()), this, SLOT(ratesChanged()));
         connect(ui->rawSensorLineEdit, SIGNAL(editingFinished()), this, SLOT(ratesChanged()));
 
+        ui->MavlinkspinBox->setValue(QGC::MavlinkID());
+        connect(ui->MavlinkspinBox, SIGNAL(valueChanged(int)), this, SLOT(mavIdChanged(int)));
+
         connect(UASManager::instance(),SIGNAL(activeUASSet(UASInterface*)),this,SLOT(setActiveUAS(UASInterface*)));
         setActiveUAS(UASManager::instance()->getActiveUAS());
 
@@ -276,6 +279,12 @@ void QGCSettingsWidget::ratesChanged()
             mav->RequestAllDataStreams();
         }
     }
+}
+
+void QGCSettingsWidget::mavIdChanged(int id)
+{
+    quint8 localID = static_cast<quint8>(id);
+    QGC::setMavlinkID(localID);
 }
 
 void QGCSettingsWidget::setBetaRelease(bool state)

--- a/src/ui/QGCSettingsWidget.h
+++ b/src/ui/QGCSettingsWidget.h
@@ -14,10 +14,12 @@ class QGCSettingsWidget : public QDialog
     Q_OBJECT
 
 public:
-    QGCSettingsWidget(QWidget *parent = 0, Qt::WindowFlags flags = Qt::Sheet);
-    ~QGCSettingsWidget();
+    QGCSettingsWidget(QWidget *parent = nullptr, Qt::WindowFlags flags = Qt::Sheet);
+    ~QGCSettingsWidget() override;
+
 protected:
-    void showEvent(QShowEvent *evt);
+    void showEvent(QShowEvent *evt) override;
+
 private slots:
     void setLogDir();
     void setMAVLinkLogDir();
@@ -29,6 +31,8 @@ private slots:
     void setHideDonateButton(bool state);
 
     void setActiveUAS(UASInterface *uas);
+
+    void mavIdChanged(int id);
 
 private:
     void setDataRateLineEdits();

--- a/src/ui/QGCSettingsWidget.ui
+++ b/src/ui/QGCSettingsWidget.ui
@@ -349,7 +349,7 @@
        <property name="geometry">
         <rect>
          <x>10</x>
-         <y>0</y>
+         <y>120</y>
          <width>501</width>
          <height>161</height>
         </rect>
@@ -433,6 +433,51 @@
          </layout>
         </item>
        </layout>
+      </widget>
+      <widget class="QLabel" name="label_14">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>70</y>
+         <width>171</width>
+         <height>25</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Mavlink ID of Apm Planner</string>
+       </property>
+      </widget>
+      <widget class="QSpinBox" name="MavlinkspinBox">
+       <property name="geometry">
+        <rect>
+         <x>180</x>
+         <y>70</y>
+         <width>100</width>
+         <height>25</height>
+        </rect>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>255</number>
+       </property>
+       <property name="value">
+        <number>252</number>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_29">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>20</y>
+         <width>511</width>
+         <height>31</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;After changing the settings on this page you have to restart APM Planner&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
       </widget>
      </widget>
     </widget>


### PR DESCRIPTION
Mavlink ID of APM Planner is configurable now.