### PR TITLE
Fix timesync message and more

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -133,6 +133,14 @@ const static quint8 defaultMavlinkSystemId = 252; // Using 252 to 'crudely' iden
         GlobalObject::sharedInstance()->setMavlinkID(ID);
     }
 
+    inline quint8 ComponentID(){
+        return GlobalObject::sharedInstance()->ComponentID();
+    }
+
+    inline void setComponentID(const quint8 ID){
+        GlobalObject::sharedInstance()->setComponentID(ID);
+    }
+
 
     //Returns the absolute parth to the files, data, qml support directories
     //It could be in 1 of 2 places under Linux

--- a/src/globalobject.cc
+++ b/src/globalobject.cc
@@ -1,6 +1,7 @@
 #include "logging.h"
 #include "configuration.h"
 #include "globalobject.h"
+#include "mavlink.h"
 #include <QSettings>
 #include <QDateTime>
 #include <QDir>
@@ -36,6 +37,7 @@ void GlobalObject::loadSettings()
     m_parameterDirectory = settings.value("PARAMETER_DIRECTORY", defaultParameterDirectory()).toString();
     m_missionDirectory = settings.value("MISSION_DIRECTORY", defaultMissionDirectory()).toString();
     m_mavlinkID = static_cast<quint8>(settings.value("MAVLINK_ID", defaultMavlinkID()).toUInt());
+    m_componentID = static_cast<quint8>(settings.value("COMPONENT_ID", defaultComponentID()).toUInt());
 
     settings.endGroup();
 }
@@ -51,6 +53,7 @@ void GlobalObject::saveSettings()
     settings.setValue("PARAMETER_DIRECTORY", m_parameterDirectory);
     settings.setValue("MISSION_DIRECTORY", m_missionDirectory);
     settings.setValue("MAVLINK_ID", m_mavlinkID);
+    settings.setValue("COMPONENT_ID", m_componentID);
 
     settings.sync();
 }
@@ -203,6 +206,25 @@ quint8 GlobalObject::MavlinkID()
 void GlobalObject::setMavlinkID(const quint8 mavlinkID)
 {
     m_mavlinkID = mavlinkID;
+}
+
+//
+// Component ID of APM Planner when uploading Waypoints via mavlink
+//
+
+quint8 GlobalObject::defaultComponentID()
+{
+    return MAV_COMP_ID_MISSIONPLANNER;
+}
+
+quint8 GlobalObject::ComponentID()
+{
+    return m_componentID;
+}
+
+void GlobalObject::setComponentID(const quint8 componentID)
+{
+    m_componentID = componentID;
 }
 
 

--- a/src/globalobject.h
+++ b/src/globalobject.h
@@ -72,6 +72,10 @@ public:
     quint8 MavlinkID();
     void setMavlinkID(const quint8 mavlinkID);
 
+    quint8 defaultComponentID();
+    quint8 ComponentID();
+    void setComponentID(const quint8 mavlinkID);
+
     QString shareDirectory();
 
 private:
@@ -83,6 +87,7 @@ private:
     QString m_parameterDirectory;
     QString m_missionDirectory;
     quint8  m_mavlinkID;
+    quint8  m_componentID;
 
 };
 

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -1436,7 +1436,7 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
 //            QLOG_DEBUG() << "timesync tc1:" << timeSync.tc1 << " ts1:" << timeSync.ts1;
 
             mavlink_message_t answer;
-            mavlink_msg_timesync_encode(message.sysid, message.compid, &answer, &timeSync);
+            mavlink_msg_timesync_encode(systemId, componentId, &answer, &timeSync);
             sendMessage(answer);
             break;
         }

--- a/src/uas/UASWaypointManager.h
+++ b/src/uas/UASWaypointManager.h
@@ -197,6 +197,8 @@ private:
     bool standalone;                                ///< If standalone is set, do not write to UAS
     quint16 uasid;
 
+    quint8 m_waypointComponentID{0};               ///< Component ID used for waypoint transmission
+
     double m_defaultAcceptanceRadius;                 ///< Default Acceptance Radius in meters
     double m_defaultRelativeAlt;                      ///< Default relative alt in meters
 

--- a/src/ui/QGCSettingsWidget.cc
+++ b/src/ui/QGCSettingsWidget.cc
@@ -109,6 +109,10 @@ void QGCSettingsWidget::showEvent(QShowEvent *evt)
         ui->MavlinkspinBox->setValue(QGC::MavlinkID());
         connect(ui->MavlinkspinBox, SIGNAL(valueChanged(int)), this, SLOT(mavIdChanged(int)));
 
+        ui->ComponentspinBox->setValue(QGC::ComponentID());
+        connect(ui->ComponentspinBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &QGCSettingsWidget::componentIdChanged);
+        // Ahgrl sowas muss auch für componentID
+
         connect(UASManager::instance(),SIGNAL(activeUASSet(UASInterface*)),this,SLOT(setActiveUAS(UASInterface*)));
         setActiveUAS(UASManager::instance()->getActiveUAS());
 
@@ -284,6 +288,12 @@ void QGCSettingsWidget::mavIdChanged(int id)
 {
     quint8 localID = static_cast<quint8>(id);
     QGC::setMavlinkID(localID);
+}
+
+void QGCSettingsWidget::componentIdChanged(int id)
+{
+    quint8 localID = static_cast<quint8>(id);
+    QGC::setComponentID(localID);
 }
 
 void QGCSettingsWidget::setBetaRelease(bool state)

--- a/src/ui/QGCSettingsWidget.h
+++ b/src/ui/QGCSettingsWidget.h
@@ -34,6 +34,8 @@ private slots:
 
     void mavIdChanged(int id);
 
+    void componentIdChanged(int id);
+
 private:
     void setDataRateLineEdits();
 

--- a/src/ui/QGCSettingsWidget.ui
+++ b/src/ui/QGCSettingsWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1014</width>
-    <height>701</height>
+    <height>839</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="general">
       <attribute name="title">
@@ -439,9 +439,14 @@
         <rect>
          <x>10</x>
          <y>70</y>
-         <width>171</width>
+         <width>170</width>
          <height>25</height>
         </rect>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>8</pointsize>
+        </font>
        </property>
        <property name="text">
         <string>Mavlink ID of Apm Planner</string>
@@ -450,11 +455,14 @@
       <widget class="QSpinBox" name="MavlinkspinBox">
        <property name="geometry">
         <rect>
-         <x>180</x>
+         <x>160</x>
          <y>70</y>
          <width>100</width>
          <height>25</height>
         </rect>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mavlink ID used by APM-Planner when communicating with the UAS. Normally there is no need to change the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="minimum">
         <number>1</number>
@@ -477,6 +485,46 @@
        </property>
        <property name="text">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;After changing the settings on this page you have to restart APM Planner&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_15">
+       <property name="geometry">
+        <rect>
+         <x>340</x>
+         <y>60</y>
+         <width>180</width>
+         <height>50</height>
+        </rect>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;Mavlink component ID&lt;br/&gt;when uploading waypoints&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+      <widget class="QSpinBox" name="ComponentspinBox">
+       <property name="geometry">
+        <rect>
+         <x>500</x>
+         <y>70</y>
+         <width>100</width>
+         <height>25</height>
+        </rect>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Component ID used by APM-Planner when uploading waypoints to a UAS. Normally there is no need to change the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>255</number>
+       </property>
+       <property name="value">
+        <number>190</number>
        </property>
       </widget>
      </widget>


### PR DESCRIPTION
Fixed timesync message using wrong mavlink ID. 
Added possibility to change the component ID used by APM-Planner when handling waypoints