### PR TITLE
Build: Correction of the “.gitignore” and uploading missing file for SDL2 Fixes #1292

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ CMakeFiles
 *Makefile*
 tags
 build*/
-Info.plist
 obj
 .DS_Store
 *.log

--- a/libs/lib/Frameworks/SDL2.framework/Versions/A/Resources/Info.plist
+++ b/libs/lib/Frameworks/SDL2.framework/Versions/A/Resources/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildMachineOSBuild</key>
+	<string>22F82</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>SDL2</string>
+	<key>CFBundleGetInfoString</key>
+	<string>http://www.libsdl.org</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.libsdl.SDL2</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Simple DirectMedia Layer</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.28.1</string>
+	<key>CFBundleSignature</key>
+	<string>SDLX</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>2.28.1</string>
+	<key>DTCompiler</key>
+	<string>com.apple.compilers.llvm.clang.1_0</string>
+	<key>DTPlatformBuild</key>
+	<string></string>
+	<key>DTPlatformName</key>
+	<string>macosx</string>
+	<key>DTPlatformVersion</key>
+	<string>13.3</string>
+	<key>DTSDKBuild</key>
+	<string>22E245</string>
+	<key>DTSDKName</key>
+	<string>macosx13.3</string>
+	<key>DTXcode</key>
+	<string>1431</string>
+	<key>DTXcodeBuild</key>
+	<string>14E300c</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.11</string>
+</dict>
+</plist>


### PR DESCRIPTION
we need to do 
make distclean
qmake -spec macx-clang apm_planner.pro
make -j8
to make sure the framework will be added properly into the build of the app