### PR TITLE
Fix compilation with newer MSVC

### DIFF
--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -121,7 +121,7 @@ WindowsCrossBuild {
     }
 
     DEPLOY_TARGET = $$DESTDIR/$${TARGET}.exe
-    QMAKE_POST_LINK += && windeployqt --no-compiler-runtime --qmldir=$${BASEDIR}/qml $${DEPLOY_TARGET}
+    QMAKE_POST_LINK += && $$[QT_INSTALL_PREFIX]/bin/windeployqt --no-compiler-runtime --qmldir=$${BASEDIR}/qml $${DEPLOY_TARGET}
 }
 
 WindowsBuild {
@@ -162,7 +162,7 @@ WindowsBuild {
                 QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY \"C:\\Windows\\System32\\msvcr120.dll\"  \"$$DESTDIR_WIN\"
         }
         else {
-                error("Visual studio version not supported, installation cannot be completed.")
+                message("Visual studio runtime has to be deployed separately")
         }
     }
     DEPLOY_TARGET = $$shell_quote($$shell_path($$DESTDIR_WIN\\$${TARGET}.exe))

--- a/apm_planner.pro
+++ b/apm_planner.pro
@@ -83,7 +83,7 @@ linux-g++ | linux-g++-32 {
         message(Fedora Build)
         DEFINES += Q_FEDORA
     }
-} else : win32-msvc2012 | win32-msvc2013 {
+} else : win32-msvc {
     message(Windows build)
     CONFIG += WindowsBuild
 }  else : win32-g++|win64-g++ {

--- a/src/main.cc
+++ b/src/main.cc
@@ -35,6 +35,8 @@ This file is part of the QGROUNDCONTROL project
 #include "logging.h"
 
 #include <fstream>
+#include <iostream>
+
 #include <QApplication>
 #include <QMutexLocker>
 


### PR DESCRIPTION
- there is nothing specific to MSVC2013 in the code, the project compiles/works with MSVC2019 just fine;
- MSVC-version specific deployement of runtime for version 2015 and higher is not implemented - to be done separately if needed;

---
This is not to claim the support of newer MSVC, but rather to allow local development/changes/experimantation.