### PR TITLE
Support for HighDPI screens/monitors

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -110,6 +110,8 @@ int main(int argc, char *argv[])
     QCoreApplication::setAttribute(Qt::AA_X11InitThreads);
 #endif
 
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
     // Init application
     QGCCore core(argc, argv);
 


### PR DESCRIPTION
Relates to: #928

---
Essentially, this does not brings a full support of HighDPI screens.
There're still some visual artifacts, like low-resolution resources/images scaled up. Eacho one of those needs to be reviewed/handles separately.
But for the most part, because the original Application is written very well, all of the UI (as far as I could check myself) is scaled much better, so that all elements are of more comfortable size.