### PR TITLE
Build: Fix #1309 SDL2 fails in QtCreator

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -283,7 +283,8 @@ WindowsBuild : win32 : exists(src/lib/opalrt/OpalApi.h) : exists(C:/OPAL-RT/RT-L
 #
 
 MacBuild {
-    QMAKE_CXXFLAGS += -F./libs/lib/Frameworks 
+    QMAKE_CXXFLAGS += -F$$BASEDIR/libs/lib/Frameworks
+
     INCLUDEPATH += \
         $$BASEDIR/libs/lib/Frameworks/SDL2.framework/Headers
 


### PR DESCRIPTION
Fixes build issue in QtCreator from SDK include in macOS

Tested  macOS 14.3.1 with Qt5.15.12