### PR TITLE
Fixes Vagrant file to use datavisualizations module

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,97 +6,101 @@
 require 'yaml'
 
 current_dir    = File.dirname(File.expand_path(__FILE__))
-configfile        = YAML.load_file("#{current_dir}/.vagrantconfig.yml")
-yaml_config = configfile['configs']['dev']
+configfile     = YAML.load_file("#{current_dir}/.vagrantconfig.yml")
+yaml_config    = configfile['configs']['dev']
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu/focal64"
+  # Updated to Ubuntu 24.04 Noble Numbat
+  config.vm.box = "ubuntu/jammy64"
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", "4096"]
-    vb.customize ["modifyvm", :id, "--cpus", "1"]
+    vb.customize ["modifyvm", :id, "--cpus", "4"]
   end
 
   $config_shell = <<-'SHELL'
-     set -e
-     set -x
+    set -e
+    set -x
 
-     sudo apt-get update
-     sudo apt-get dist-upgrade -y
-     sudo apt-get install -y ccache wget git build-essential
+    export DEBIAN_FRONTEND=noninteractive
 
-     sudo apt-get install -y libglu1-mesa-dev
+    # Update and Upgrade
+    sudo apt-get update -y
+    sudo apt-get dist-upgrade -y
 
-     sudo apt-get install -y aptitude
-     sudo aptitude install -y flite1-dev libsdl2-dev libsdl1.2-dev libsndfile-dev libssl-dev libudev-dev
+    # Essential Packages
+    sudo apt install -y ccache wget git build-essential \
+      libglu1-mesa-dev flite1-dev libsdl2-dev libsdl1.2-dev libsndfile-dev libssl-dev libudev-dev \
+      python3-serial python3-pexpect python3-pip patchelf
 
-     sudo aptitude install -y \
-          python3-serial \
-          python3-pexpect
+    # Install Qt dependencies
+    sudo apt install -y qt5-qmake qtbase5-dev qtscript5-dev libqt5webkit5-dev \
+      libqt5serialport5-dev libqt5svg5-dev libqt5opengl5-dev qml-module-qtquick-controls \
+      libqt5datavisualization5-dev
+          
 
-     # taken from travis.yml
-     echo 'Initialising submodules'
-     su - vagrant -c 'cd %{project_root_dir}; git submodule init && git submodule update'
+    # Clean up apt cache to save space
+    sudo apt-get clean
+    sudo rm -rf /var/lib/apt/lists/*
 
-     # with reference to https://github.com/jurplel/install-qt-action/blob/master/src/main.ts and .github/workflows/linux_release.yml:
-     echo 'Installing QT'
-     apt-get install -y python3-pip
-     su - vagrant -c "pip3 install --user aqtinstall"
+    # Initialize submodules
+    echo 'Initialising submodules'
+    su - vagrant -c 'cd %{project_root_dir}; git submodule update --init --recursive'
 
-     apt-get install -y patchelf
+    # Install aqtinstall for Qt setup
+    #su - vagrant -c "pip3 install --user aqtinstall"
 
-     dir="%{qt_deps_unpack_dir}"
-     version="%{qt_deps_ver}"
-     host="linux"
-     target="desktop"
-     modules="qtcharts"
-     su - vagrant -c "rm -rf ${dir}"
-     su - vagrant -c "mkdir -p ${dir}"
-     su - vagrant -c "python3 -m aqt install-qt -O ${dir} ${host} ${target} ${version} -m ${modules}"
+    # Install Qt dependencies
+    # This is the old way to install pre-built version of Qt5.
+    # dir="%{qt_deps_unpack_dir}"
+    # version="%{qt_deps_ver}"
+    # host="linux"
+    # target="desktop"
+    # modules="qtcharts"
+    # su - vagrant -c "rm -rf ${dir}"
+    # su - vagrant -c "mkdir -p ${dir}"
+    # su - vagrant -c "python3 -m aqt install-qt -O ${dir} ${host} ${target} ${version} -m ${modules}"
 
+    # # Copy Qt deps into the shadow-build directory
+    # su - vagrant -c 'mkdir -p %{qt_deps_dir}'
+    # su - vagrant -c 'cp -a %{qt_deps_bin_unpack_dir} %{qt_deps_bin_dir}'
+    # su - vagrant -c 'cp -a %{qt_deps_lib_unpack_dir} %{qt_deps_lib_dir}'
+    # su - vagrant -c 'cp -a %{qt_deps_plugins_unpack_dir} %{qt_deps_plugins_dir}'
+    # su - vagrant -c 'cp -a %{qt_deps_qml_unpack_dir} %{qt_deps_qml_dir}'
 
-     # copy Qt deps into the shadow-build directory so that the
-     # compiled binary can find them in its LD_LIBRARY_PATH:
-     su - vagrant -c 'mkdir -p %{qt_deps_dir}'
-     su - vagrant -c 'cp -a %{qt_deps_bin_unpack_dir} %{qt_deps_bin_dir}'
-     su - vagrant -c 'cp -a %{qt_deps_lib_unpack_dir} %{qt_deps_lib_dir}'
-     su - vagrant -c 'cp -a %{qt_deps_plugins_unpack_dir} %{qt_deps_plugins_dir}'
-     su - vagrant -c 'cp -a %{qt_deps_qml_unpack_dir} %{qt_deps_qml_dir}'
-
-     # write out a pair of scripts to make rebuilding on the VM easy:
-     su - vagrant -c "cat <<QMAKE >do-qmake.sh
+    # Write out scripts for build commands
+    su - vagrant -c "cat <<'QMAKE' >do-qmake.sh
 #!/bin/bash
 
 set -e
 set -x
 
 cd %{shadow_build_dir}
-export LD_LIBRARY_PATH=%{qt_deps_lib_unpack_dir}
+#export LD_LIBRARY_PATH=%{qt_deps_lib_unpack_dir}
 export PATH=%{qt_deps_bin_unpack_dir}:\$PATH
 qmake -r %{pro} CONFIG+=\${CONFIG} CONFIG+=WarningsAsErrorsOn -spec %{spec}
 QMAKE
 "
-
-     su - vagrant -c "cat <<MAKE >do-make.sh
+    su - vagrant -c "cat <<'MAKE' >do-make.sh
 #!/bin/bash
 
 set -e
 set -x
 
 cd %{shadow_build_dir}
-export LD_LIBRARY_PATH=%{qt_deps_lib_unpack_dir}
+#export LD_LIBRARY_PATH=%{qt_deps_lib_unpack_dir}
 export PATH=%{qt_deps_bin_unpack_dir}:\$PATH
-make -j1
+make -j4
 MAKE
 "
     su - vagrant -c "chmod +x do-qmake.sh do-make.sh"
 
-    # now run the scripts:
+    # Run the build scripts
     su - vagrant -c ./do-qmake.sh
     su - vagrant -c ./do-make.sh
 
-   SHELL
+  SHELL
 
-  config.vm.provision "dev", type: "shell", inline: $config_shell  % {
+  config.vm.provision "dev", type: "shell", inline: $config_shell % {
     :shadow_build_dir => yaml_config['shadow_build_dir'],
     :pro => yaml_config['pro'],
     :spec => yaml_config['spec'],
@@ -117,6 +121,5 @@ MAKE
     :qt_deps_plugins_dir => yaml_config['qt_deps_plugins_dir'],
     :qt_deps_qml_dir => yaml_config['qt_deps_qml_dir'],
   }
-
 
 end


### PR DESCRIPTION
- Vagrant now uses Qt5 on ubuntu 22.04 LTS
- Drops using aqt as it does not have datavisualizations built in.